### PR TITLE
SM-39 학생 검색시 검색이 안되는 버그 수정

### DIFF
--- a/src/api/student/student.service.ts
+++ b/src/api/student/student.service.ts
@@ -39,11 +39,11 @@ export default class StudentService extends BaseService<IStudent> {
         // searchWord가 비어있으면 삭제
         switch (searchOption) {
             case 'societyName':
-                !!!searchWord ? delete where.society_name : where.society_name = searchWord;
+                !!!searchWord ? delete where.society_name : where.society_name = { [Op.like]: `%${searchWord}%` };
                 delete where.catholic_name
                 break;
             case 'catholicName':
-                !!!searchWord ? delete where.catholic_name : where.catholic_name = searchWord;
+                !!!searchWord ? delete where.catholic_name : where.catholic_name = { [Op.like]: `%${searchWord}%` };
                 delete where.society_name
                 break;
             default:


### PR DESCRIPTION
학생 검색시 일부 기능이 정상적으로 동작하지 않는 버그를 발견하였습니다.

이에 like 연산자를 사용하여 DB에서 찾도록 합니다.

추후에 데이터의 양이 많아지면 검색엔진을 사용하도록 합니다.