### PR TITLE
SM-41 트랜잭션 처리 관련 리팩토링

### DIFF
--- a/src/api/attendance/attendance.repository.ts
+++ b/src/api/attendance/attendance.repository.ts
@@ -1,6 +1,4 @@
 ﻿/* eslint-disable @typescript-eslint/no-explicit-any */
-import logger from '@/lib/logger'
-
 import { Attendance } from '@/models/attendance.model';
 import BaseRepository from '@/common/base/base.repository';
 import { IAttendance } from '@/@types/attendance';
@@ -58,24 +56,11 @@ export default class AttendanceRepository extends BaseRepository<Attendance> {
     }
 
     async create(param: IAttendance): Promise<Attendance> {
-        let attendance;
-
-        try {
-            attendance = await Attendance.create({
-                date: param.date,
-                content: param.content,
-                student_id: this._id,
-            }, { transaction: this.transaction });
-
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            attendance = null;
-        }
-
-        return attendance;
+        return await Attendance.create({
+            date: param.date,
+            content: param.content,
+            student_id: this._id,
+        }, { transaction: this.transaction });
     }
 
     /**
@@ -85,29 +70,18 @@ export default class AttendanceRepository extends BaseRepository<Attendance> {
      * @returns
      */
     async modify(param: IAttendance): Promise<number> {
-        let attendance: number;
-
-        try {
-            [ attendance ] = await Attendance.update(
-                {
-                    content: param.content,
+        const [ attendance ] = await Attendance.update(
+            {
+                content: param.content,
+            },
+            {
+                where: {
+                    date: param.date,
+                    student_id: this._id,
                 },
-                {
-                    where: {
-                        date: param.date,
-                        student_id: this._id,
-                    },
-                    transaction: this.transaction,
-                }
-            );
-
-            await this.transaction.commit();
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            attendance = 0;
-        }
-
+                transaction: this.transaction,
+            }
+        );
         return attendance;
     }
 
@@ -123,26 +97,14 @@ export default class AttendanceRepository extends BaseRepository<Attendance> {
      * @returns
      */
     async destroy(date: string): Promise<Attendance> {
-        let attendance: Attendance;
-
-        try {
-            attendance = await this.setId(this._id).get(date);
-            await Attendance.destroy({
-                where: {
-                    date,
-                    student_id: this._id,
-                },
-                transaction: this.transaction
-            });
-
-            await this.transaction.commit();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            attendance = null;
-        }
-
+        const attendance: Attendance = await this.setId(this._id).get(date);
+        await Attendance.destroy({
+            where: {
+                date,
+                student_id: this._id,
+            },
+            transaction: this.transaction
+        });
         return attendance;
     }
 

--- a/src/api/group/group.repository.ts
+++ b/src/api/group/group.repository.ts
@@ -1,16 +1,14 @@
 ﻿/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { Sequelize, Op } from 'sequelize';
+import { Op } from 'sequelize';
 
 import { IGroup } from '@/@types/group';
 
 import BaseRepository from '@/common/base/base.repository';
 
-import logger from '@/lib/logger'
-
 import { Group } from '@/models/group.model';
 
 export default class GroupRepository extends BaseRepository<Group> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     findAndCountAll(where: any): Promise<{ rows: any; count: number; }> {
         throw new Error('Method not implemented.');
     }
@@ -71,89 +69,31 @@ export default class GroupRepository extends BaseRepository<Group> {
     }
 
     async create(param: IGroup): Promise<Group> {
-        let group: Group;
-
-        try {
-            group = await Group.create({
-                name: param.name,
-                account_id: param.accountId
-            }, { transaction: this.transaction });
-
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            group = null;
-        }
-
-        return group;
+        return await Group.create({
+            name: param.name,
+            account_id: param.accountId
+        }, { transaction: this.transaction });
     }
 
     async update(param: IGroup): Promise<Group> {
-        let group: Group;
-
-        try {
-            group = await this.setId(param._id).findOne();
-            group.name = param.name;
-            group.account_id = param.accountId;
-            await group.save({
-                transaction: this.transaction,
-                fields: ['name', 'account_id']
-            });
-            // 변경된 후의 객체를 반환해야 함. 그래서 이 부분은 주석 처리하였음.
-            // await Group.update(
-            //     {
-            //         name: param.name,
-            //         account_id: param.accountId
-            //     },
-            //     {
-            //         where: {
-            //             _id: param._id
-            //         },
-            //         transaction: this.transaction
-            //     }
-            // );
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            group = null;
-        }
+        const group: Group = await this.setId(param._id).findOne();
+        group.name = param.name;
+        group.account_id = param.accountId;
+        await group.save({
+            transaction: this.transaction,
+            fields: ['name', 'account_id']
+        });
 
         return group;
     }
 
     async delete(): Promise<Group> {
-        let group: Group;
-
-        try {
-            group = await this.findOne();
-            group.delete_at = new Date();
-            await group.save({
-                transaction: this.transaction,
-                fields: [ 'delete_at' ]
-            });
-            // 변경된 후의 객체를 반환해야 함. 그래서 이 부분은 주석 처리하였음.
-            // await Group.update(
-            //     {
-            //         delete_at: Sequelize.literal('CURRENT_TIMESTAMP')
-            //     },
-            //     {
-            //         where: {
-            //             _id: this._id
-            //         },
-            //         transaction: this.transaction
-            //     }
-            // );
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            group = null;
-        }
+        const group: Group = await this.findOne();
+        group.delete_at = new Date();
+        await group.save({
+            transaction: this.transaction,
+            fields: [ 'delete_at' ]
+        });
 
         return group;
     }

--- a/src/api/group/group.service.ts
+++ b/src/api/group/group.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import GroupRepository from './group.repository';
 
 import { IGroup } from '@/@types/group';
@@ -6,6 +7,8 @@ import ApiCode from '@/common/api.code';
 import ApiError from '@/common/api.error';
 import GroupDTO from '@/common/dto/group.dto';
 import BaseService from '@/common/base/base.service';
+
+import logger from '@/lib/logger';
 
 import { Group } from '@/models/group.model';
 
@@ -42,22 +45,46 @@ export default class GroupService extends BaseService<IGroup> {
 
     async add(param: IGroup): Promise<IGroup> {
         const transaction = await new GroupRepository().setTransaction();
-        const group: Group = await transaction.create(param);
 
-        return new GroupDTO(group).group;
+        try {
+            const group = await transaction.create(param);
+            await transaction.commit();
+            return new GroupDTO(group).group;
+        } catch(e: any) {
+            logger.err(e);
+            logger.error(e);
+            await transaction.rollback();
+            throw new ApiError(ApiCode.INTERNAL_SERVER_ERROR, `${e}`);
+        }
     }
 
     async modify(param: IGroup): Promise<IGroup> {
         const transaction = await new GroupRepository().setTransaction();
-        const group: Group = await transaction.update(param);
 
-        return new GroupDTO(group).group;
+        try {
+            const group = await transaction.update(param);
+            await transaction.commit();
+            return new GroupDTO(group).group;
+        } catch(e: any) {
+            logger.err(e);
+            logger.error(e);
+            await transaction.rollback();
+            throw new ApiError(ApiCode.INTERNAL_SERVER_ERROR, `${e}`);
+        }
     }
 
     async remove(): Promise<IGroup> {
         const transaction = await new GroupRepository().setId(this._id).setTransaction();
-        const group: Group = await transaction.delete();
 
-        return new GroupDTO(group).group;
+        try {
+            const group = await transaction.delete();
+            await transaction.commit();
+            return new GroupDTO(group).group;
+        } catch(e: any) {
+            logger.err(e);
+            logger.error(e);
+            await transaction.rollback();
+            throw new ApiError(ApiCode.INTERNAL_SERVER_ERROR, `${e}`);
+        }
     }
 }

--- a/src/api/student/student.repository.ts
+++ b/src/api/student/student.repository.ts
@@ -5,8 +5,6 @@ import { IStudent } from '@/@types/student';
 
 import BaseRepository from '@/common/base/base.repository';
 
-import logger from '@/lib/logger'
-
 import { Group } from '@/models/group.model';
 import { Student } from '@/models/student.model';
 
@@ -103,112 +101,51 @@ export default class StudentRepository extends BaseRepository<Student> {
     }
 
     async create(param: IStudent): Promise<Student> {
-        let student: Student;
-
-        try {
-            student = await Student.create({
-                society_name: param.societyName,
-                catholic_name: param.catholicName,
-                age: param.age,
-                contact: param.contact,
-                description: param.description,
-                group_id: param.groupId,
-                baptized_at: param.baptizedAt,
-            }, { transaction: this.transaction });
-
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            student = null;
-        }
-
-        return student;
+        return await Student.create({
+            society_name: param.societyName,
+            catholic_name: param.catholicName,
+            age: param.age,
+            contact: param.contact,
+            description: param.description,
+            group_id: param.groupId,
+            baptized_at: param.baptizedAt,
+        }, { transaction: this.transaction });
     }
 
     async update(param: IStudent): Promise<Student> {
-        let student: Student;
+        const student: Student = await this.setId(param._id).findOne();
+        student.society_name = param.societyName;
+        student.catholic_name = param.catholicName;
+        student.age = param.age;
+        student.contact = param.contact;
+        student.description = param.description;
+        student.group_id = param.groupId;
+        student.baptized_at = param.baptizedAt;
 
-        try {
-            student = await this.setId(param._id).findOne();
-            student.society_name = param.societyName;
-            student.catholic_name = param.catholicName;
-            student.age = param.age;
-            student.contact = param.contact;
-            student.description = param.description;
-            student.group_id = param.groupId;
-            student.baptized_at = param.baptizedAt;
-            await student.save({
-                transaction: this.transaction,
-                fields: [
-                    'society_name',
-                    'catholic_name',
-                    'age',
-                    'contact',
-                    'description',
-                    'group_id',
-                    'baptized_at'
-                ]
-            });
-            // 변경된 후의 객체를 반환해야 함. 그래서 이 부분은 주석 처리하였음.
-            // await Student.update(
-            //     {
-            //         society_name: param.societyName,
-            //         catholic_name: param.catholicName,
-            //         age: param.age,
-            //         contact: param.contact,
-            //         description: param.description,
-            //         group_id: param.groupId,
-            //         baptized_at: param.baptizedAt,
-            //     },
-            //     {
-            //         where: {
-            //             _id: param._id
-            //         },
-            //         transaction: this.transaction
-            //     },
-            // );
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            student = null;
-        }
+        await student.save({
+            transaction: this.transaction,
+            fields: [
+                'society_name',
+                'catholic_name',
+                'age',
+                'contact',
+                'description',
+                'group_id',
+                'baptized_at'
+            ]
+        });
 
         return student;
     }
 
     async delete(): Promise<Student> {
-        let student: Student;
+        const student: Student = await this.findOne();
+        student.delete_at = new Date();
 
-        try {
-            student = await this.findOne();
-            student.delete_at = new Date();
-            await student.save({
-                transaction: this.transaction,
-                fields: [ 'delete_at' ]
-            });
-            // 변경된 후의 객체를 반환해야 함. 그래서 이 부분은 주석 처리하였음.
-            // await Student.update(
-            //     {
-            //         delete_at: Sequelize.literal('CURRENT_TIMESTAMP')
-            //     },
-            //     {
-            //         where: {
-            //             _id: this._id
-            //         },
-            //         transaction: this.transaction
-            //     }
-            // );
-            await this.transaction.commit();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
-            logger.error(e);
-            await this.transaction.rollback();
-            student = null;
-        }
+        await student.save({
+            transaction: this.transaction,
+            fields: [ 'delete_at' ]
+        });
 
         return student;
     }

--- a/src/common/base/base.repository.ts
+++ b/src/common/base/base.repository.ts
@@ -29,6 +29,14 @@ export default abstract class BaseRepository<T> {
         return this;
     }
 
+    async commit() {
+        await this.transaction.commit();
+    }
+
+    async rollback() {
+        await this.transaction.rollback();
+    }
+
     abstract findAll(): Promise<T[]>;
     abstract findAndCountAll(where: any): Promise<{rows: any; count: number}>; // pagenation
     abstract findOne(): Promise<T>;


### PR DESCRIPTION
service단에서 트랜잭션을 처리하도록 관리합니다.

service단에서 트랜잭션을 관리하게 되면 이점은 다음과 같습니다.

1. 불필요한 트랜잭션의 남발하는 것을 없앨 수 있습니다.
2. 학생의 졸업이나 출석 입력같은 중요한 데이터의 무결성을 유지할 수 있습니다.

이에 service단에서 트랜잭션을 처리하도록 결정하였고, 수정하였습니다.

출석 입력의 경우 기존보다 30% 성능 향상하였습니다.