### PR TITLE
fix: 통계 학생 수 조회 정확성 개선

### DIFF
--- a/apps/api/test/integration/statistics.test.ts
+++ b/apps/api/test/integration/statistics.test.ts
@@ -68,6 +68,7 @@ describe('statistics 통합 테스트', () => {
             const mockGroup = createMockGroup({ accountId: BigInt(accountId) });
 
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup]);
+            mockPrismaClient.student.count.mockResolvedValueOnce(1);
             mockPrismaClient.attendance.findMany.mockResolvedValueOnce([
                 createMockAttendance({
                     studentId: BigInt(1),
@@ -103,6 +104,7 @@ describe('statistics 통합 테스트', () => {
             const mockGroup = createMockGroup({ accountId: BigInt(accountId) });
 
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup]);
+            mockPrismaClient.student.count.mockResolvedValueOnce(1);
             mockPrismaClient.attendance.findMany.mockResolvedValueOnce([
                 createMockAttendance({
                     studentId: BigInt(1),
@@ -136,6 +138,7 @@ describe('statistics 통합 테스트', () => {
             const mockGroup = createMockGroup({ accountId: BigInt(accountId) });
 
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup]);
+            mockPrismaClient.student.count.mockResolvedValueOnce(1);
             mockPrismaClient.attendance.findMany.mockResolvedValueOnce([
                 createMockAttendance({
                     studentId: BigInt(1),
@@ -163,6 +166,12 @@ describe('statistics 통합 테스트', () => {
 
             // group.findMany
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup]);
+            // student.findMany (그룹 소속 전체 학생 조회)
+            mockPrismaClient.student.findMany.mockResolvedValueOnce([
+                createMockStudent({ id: BigInt(1), groupId: mockGroup.id, gender: 'M' }),
+                createMockStudent({ id: BigInt(2), groupId: mockGroup.id, gender: 'F' }),
+                createMockStudent({ id: BigInt(3), groupId: mockGroup.id, gender: null }),
+            ]);
             // attendance.findMany (기간 내 전체 출석 데이터)
             mockPrismaClient.attendance.findMany.mockResolvedValueOnce([
                 createMockAttendance({ studentId: BigInt(1), groupId: mockGroup.id, content: '◎' }),
@@ -224,6 +233,11 @@ describe('statistics 통합 테스트', () => {
 
             // group.findMany
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup1, mockGroup2]);
+            // student.findMany (그룹별 학생 수 조회)
+            mockPrismaClient.student.findMany.mockResolvedValueOnce([
+                createMockStudent({ id: BigInt(1), groupId: mockGroup1.id }),
+                createMockStudent({ id: BigInt(2), groupId: mockGroup2.id }),
+            ]);
             // attendance.findMany (groupId 기반)
             mockPrismaClient.attendance.findMany.mockResolvedValueOnce([
                 createMockAttendance({ studentId: BigInt(1), groupId: mockGroup1.id, content: '◎' }),
@@ -302,6 +316,10 @@ describe('statistics 통합 테스트', () => {
 
             // group.findMany
             mockPrismaClient.group.findMany.mockResolvedValueOnce([mockGroup]);
+            // student.findMany (그룹별 학생 수 조회)
+            mockPrismaClient.student.findMany.mockResolvedValueOnce([
+                createMockStudent({ id: BigInt(1), groupId: mockGroup.id }),
+            ]);
             // getBulkGroupSnapshots → groupSnapshot.findMany
             mockPrismaClient.groupSnapshot.findMany.mockResolvedValueOnce([
                 createMockGroupSnapshot({ groupId: mockGroup.id, name: '1반' }),


### PR DESCRIPTION
## 문제
통계 기능에서 출석 기록이 있는 학생만 카운트하여 그룹의 전체 학생 수가 반영되지 않았습니다. 이로 인해 출석률이 부풀려진 값으로 계산되었습니다.

## 변경사항
- `GetAttendanceRateUseCase`: `student.count()` 추가하여 그룹 소속 전체 학생 수 기반으로 출석률 계산
- `GetByGenderUseCase`: `student.findMany()` 추가하여 전체 학생 기반 성별 분포 계산
- `GetGroupStatisticsUseCase`: `student.findMany()` 추가하여 그룹별 전체 학생 수 기반 통계 계산
- `GetTopGroupsUseCase`: `student.findMany()` 추가하여 전체 학생 수 기반 그룹별 출석률 순위 계산

## 테스트
통계 통합 테스트 16개 모두 통과했습니다.

🤖 Generated with Claude Code