### PR TITLE
fix: SonarCloud 코드 품질 개선 — 버그 4→0, 코드스멜 150→89

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -163,8 +163,10 @@ export const main = async (): Promise<void> => {
 const isMainModule = import.meta.url === `file://${resolve(process.argv[1])}`;
 
 if (isMainModule) {
-    main().catch((e) => {
+    try {
+        await main();
+    } catch (e) {
         console.error('Failed to start server:', e);
         process.exit(1);
-    });
+    }
 }

--- a/apps/api/src/domains/attendance/application/get-day-detail.usecase.ts
+++ b/apps/api/src/domains/attendance/application/get-day-detail.usecase.ts
@@ -31,7 +31,7 @@ export class GetDayDetailUseCase {
         }
 
         // 2. 날짜에서 연도 추출하여 의무축일 확인
-        const year = parseInt(date.substring(0, 4), 10);
+        const year = Number.parseInt(date.substring(0, 4), 10);
         const holydaysUseCase = new GetHolydaysUseCase();
         const holydaysResult = await holydaysUseCase.execute({ year });
         const holyday = holydaysResult.holydays.find((h) => h.date === date)?.name ?? null;
@@ -55,7 +55,7 @@ export class GetDayDetailUseCase {
 
         // 4. 해당 날짜의 출석 데이터 조회
         // 입력 형식(YYYY-MM-DD)을 DB 형식(YYYYMMDD)으로 변환
-        const dbDate = date.replace(/-/g, '');
+        const dbDate = date.replaceAll('-', '');
         const studentIds = students.map((s) => s.id);
         const attendances = await database.attendance.findMany({
             where: {

--- a/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
@@ -8,6 +8,7 @@ import {
     countSundays,
     countSundaysInYear,
     formatDateCompact,
+    getGraduationCutoff,
     getWeekRangeInMonth,
     roundToDecimal,
 } from '@school/utils';
@@ -37,12 +38,7 @@ export class GetByGenderUseCase {
         }
 
         // 3. 그룹에 속한 전체 학생 ID 조회 (조회 기간 시작일 기준 졸업 필터 적용)
-        const graduationCutoff =
-            month && week
-                ? getWeekRangeInMonth(year, month, week).startDate
-                : month
-                  ? new Date(year, month - 1, 1)
-                  : new Date(year, 0, 1);
+        const graduationCutoff = getGraduationCutoff(year, month, week);
         const students = await database.student.findMany({
             where: {
                 groupId: { in: groupIds },

--- a/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
@@ -7,6 +7,7 @@ import type { GroupStatisticsOutput, StatisticsInput as StatisticsSchemaInput } 
 import {
     countSundays,
     formatDateCompact,
+    getGraduationCutoff,
     getThisWeekSaturday,
     getThisWeekSunday,
     getWeekRangeInMonth,
@@ -47,12 +48,7 @@ export class GetGroupStatisticsUseCase {
         }
 
         // 2. 그룹별 학생 수 조회 (조회 기간 시작일 기준 졸업 필터 적용)
-        const graduationCutoff =
-            month && week
-                ? getWeekRangeInMonth(year, month, week).startDate
-                : month
-                  ? new Date(year, month - 1, 1)
-                  : new Date(year, 0, 1);
+        const graduationCutoff = getGraduationCutoff(year, month, week);
         const students = await database.student.findMany({
             where: {
                 groupId: { in: groupIds },

--- a/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
@@ -8,6 +8,7 @@ import {
     countSundays,
     countSundaysInYear,
     formatDateCompact,
+    getGraduationCutoff,
     getWeekRangeInMonth,
     roundToDecimal,
 } from '@school/utils';
@@ -42,12 +43,7 @@ export class GetTopGroupsUseCase {
         }
 
         // 3. 그룹별 학생 수 조회 (조회 기간 시작일 기준 졸업 필터 적용)
-        const graduationCutoff =
-            month && week
-                ? getWeekRangeInMonth(year, month, week).startDate
-                : month
-                  ? new Date(year, month - 1, 1)
-                  : new Date(year, 0, 1);
+        const graduationCutoff = getGraduationCutoff(year, month, week);
         const students = await database.student.findMany({
             where: {
                 groupId: { in: groupIds },

--- a/apps/api/src/global/config/env.ts
+++ b/apps/api/src/global/config/env.ts
@@ -6,11 +6,13 @@ import { getOsEnv, getOsEnvOptional, normalizePort } from '~/global/utils/index.
 /**
  * Load .env file or for tests the .env.test file.
  */
-const postfix = process.env.NODE_ENV?.toLowerCase().includes('prod')
-    ? ''
-    : process.env.NODE_ENV?.toLowerCase().includes('dev')
-      ? '.dev'
-      : '.' + process.env.NODE_ENV;
+const getEnvPostfix = (): string => {
+    const nodeEnv = process.env.NODE_ENV?.toLowerCase();
+    if (nodeEnv?.includes('prod')) return '';
+    if (nodeEnv?.includes('dev')) return '.dev';
+    return '.' + process.env.NODE_ENV;
+};
+const postfix = getEnvPostfix();
 dotenv.config({ path: join(process.cwd(), `.env${postfix}`) });
 
 /**

--- a/apps/api/src/global/utils/utils.ts
+++ b/apps/api/src/global/utils/utils.ts
@@ -14,8 +14,8 @@ export const getOsEnvOptional = (key: string, defaultValue = ''): string => {
 };
 
 export const normalizePort = (port: string): number | string | boolean => {
-    const parsedPort = parseInt(port, 10);
-    if (isNaN(parsedPort)) {
+    const parsedPort = Number.parseInt(port, 10);
+    if (Number.isNaN(parsedPort)) {
         // named pipe
         return port;
     }

--- a/apps/api/src/infrastructure/database/database.ts
+++ b/apps/api/src/infrastructure/database/database.ts
@@ -13,7 +13,7 @@ const interpolateQuery = (query: string, params: string): string => {
     try {
         const parsedParams: unknown[] = JSON.parse(params);
         let index = 0;
-        return query.replace(/\?/g, () => {
+        return query.replaceAll('?', () => {
             const value = parsedParams[index++];
             if (value === null) return 'NULL';
             if (typeof value === 'string') return `'${value}'`;
@@ -56,11 +56,8 @@ database.$on('query', (event) => {
     // 슬로우 쿼리 감지
     if (duration >= SLOW_QUERY_THRESHOLD) {
         logger.err(`[SLOW QUERY] ${duration}ms - ${interpolated}`);
-    } else {
-        // 일반 쿼리 로깅 (개발 환경만)
-        if (env.mode.local) {
-            logger.sql(`${duration}ms - ${interpolated}`);
-        }
+    } else if (env.mode.local) {
+        logger.sql(`${duration}ms - ${interpolated}`);
     }
 });
 

--- a/apps/web/src/components/common/Pagination.tsx
+++ b/apps/web/src/components/common/Pagination.tsx
@@ -17,14 +17,12 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
             for (let i = 1; i <= totalPages; i++) {
                 pages.push(i);
             }
+        } else if (currentPage <= 3) {
+            pages.push(1, 2, 3, 4, '...', totalPages);
+        } else if (currentPage >= totalPages - 2) {
+            pages.push(1, '...', totalPages - 3, totalPages - 2, totalPages - 1, totalPages);
         } else {
-            if (currentPage <= 3) {
-                pages.push(1, 2, 3, 4, '...', totalPages);
-            } else if (currentPage >= totalPages - 2) {
-                pages.push(1, '...', totalPages - 3, totalPages - 2, totalPages - 1, totalPages);
-            } else {
-                pages.push(1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages);
-            }
+            pages.push(1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages);
         }
 
         return pages;
@@ -41,10 +39,10 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
                 이전
             </Button>
 
-            {getPageNumbers().map((page, index) =>
+            {getPageNumbers().map((page) =>
                 typeof page === 'number' ? (
                     <Button
-                        key={index}
+                        key={`page-${page}`}
                         variant={currentPage === page ? 'default' : 'outline'}
                         onClick={() => onPageChange(page)}
                         className="min-w-14"
@@ -52,7 +50,7 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
                         {page}
                     </Button>
                 ) : (
-                    <span key={index} className="px-3 py-2 text-xl text-muted-foreground">
+                    <span key={`ellipsis-${page}`} className="px-3 py-2 text-xl text-muted-foreground">
                         {page}
                     </span>
                 )

--- a/apps/web/src/features/student/hooks/useStudents.ts
+++ b/apps/web/src/features/student/hooks/useStudents.ts
@@ -18,7 +18,7 @@ interface UseStudentsOptions {
 }
 
 const parsePageParam = (value: string | null): number => {
-    const parsed = parseInt(value ?? '', 10);
+    const parsed = Number.parseInt(value ?? '', 10);
     return parsed > 0 ? parsed : 1;
 };
 

--- a/apps/web/src/pages/attendance/AttendanceModal.tsx
+++ b/apps/web/src/pages/attendance/AttendanceModal.tsx
@@ -65,20 +65,6 @@ function parseContent(content: string): { mass: boolean; catechism: boolean } {
     }
 }
 
-/**
- * 미사/교리 체크를 content 값으로 변환
- * ◎ = 출석 (미사+교리)
- * ○ = 미사만
- * △ = 교리만
- * - = 결석
- */
-function toContent(mass: boolean, catechism: boolean): string {
-    if (mass && catechism) return '◎';
-    if (mass && !catechism) return '○';
-    if (!mass && catechism) return '△';
-    return '-';
-}
-
 export function AttendanceModal({
     isOpen,
     onClose,
@@ -94,8 +80,8 @@ export function AttendanceModal({
 
     // 날짜 파싱
     const [, monthStr, dayStr] = date.split('-');
-    const month = parseInt(monthStr, 10);
-    const day = parseInt(dayStr, 10);
+    const month = Number.parseInt(monthStr, 10);
+    const day = Number.parseInt(dayStr, 10);
 
     // 요일 계산
     const dateObj = new Date(date);
@@ -131,7 +117,7 @@ export function AttendanceModal({
 
             const newMass = field === 'mass' ? checked : student.mass;
             const newCatechism = field === 'catechism' ? checked : student.catechism;
-            const content = toContent(newMass, newCatechism);
+            const content = getStatusSymbol(newMass, newCatechism);
 
             setSaveStatus('saving');
 
@@ -166,14 +152,16 @@ export function AttendanceModal({
                     {holyday && <p className="text-sm text-red-600">{holyday}</p>}
                 </DialogHeader>
 
-                {isLoading ? (
+                {isLoading && (
                     <div className="flex items-center justify-center py-8">
                         <Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" />
                         <span className="ml-2">로딩 중...</span>
                     </div>
-                ) : students.length === 0 ? (
+                )}
+                {!isLoading && students.length === 0 && (
                     <p className="py-8 text-center text-muted-foreground">학생이 없습니다.</p>
-                ) : (
+                )}
+                {!isLoading && students.length > 0 && (
                     <div className="space-y-4">
                         {/* 테이블 헤더 */}
                         <div className="grid grid-cols-[1fr_60px_60px_50px] gap-2 border-b pb-2 text-sm font-medium">

--- a/apps/web/src/pages/attendance/AttendancePage.tsx
+++ b/apps/web/src/pages/attendance/AttendancePage.tsx
@@ -199,17 +199,18 @@ export function AttendancePage() {
                 </div>
             </div>
 
-            {!selectedGroupId ? (
+            {!selectedGroupId && (
                 <Card>
                     <CardContent className="py-8 text-center text-muted-foreground">학년을 선택해주세요.</CardContent>
                 </Card>
-            ) : attendanceLoading ? (
-                <LoadingSpinner />
-            ) : !attendanceData?.students?.length ? (
+            )}
+            {selectedGroupId && attendanceLoading && <LoadingSpinner />}
+            {selectedGroupId && !attendanceLoading && !attendanceData?.students?.length && (
                 <Card>
                     <CardContent className="py-8 text-center text-muted-foreground">학생이 없습니다.</CardContent>
                 </Card>
-            ) : (
+            )}
+            {selectedGroupId && !attendanceLoading && attendanceData?.students?.length && (
                 <Card>
                     <CardContent className="overflow-x-auto p-4">
                         <table className="min-w-full border-collapse">

--- a/apps/web/src/pages/attendance/CalendarCell.tsx
+++ b/apps/web/src/pages/attendance/CalendarCell.tsx
@@ -6,16 +6,26 @@ interface CalendarCellProps {
     onClick?: (date: string) => void;
 }
 
-export function CalendarCell({ day, onClick }: CalendarCellProps) {
+const getBarColor = (isFullAttendance: boolean, hasAttendance: boolean) => {
+    if (isFullAttendance) return 'bg-green-500';
+    if (hasAttendance) return 'bg-amber-500';
+    return 'bg-muted';
+};
+
+const getTextColor = (isFullAttendance: boolean, hasAttendance: boolean) => {
+    if (isFullAttendance) return 'text-green-600';
+    if (hasAttendance) return 'text-amber-600';
+    return 'text-muted-foreground';
+};
+
+export function CalendarCell({ day, onClick }: Readonly<CalendarCellProps>) {
     if (!day) {
-        // 빈 셀 (이전/다음 달 날짜)
         return <div className="h-24 bg-muted/20 sm:h-28" />;
     }
 
     const { date, dayOfWeek, attendance, holyday } = day;
-    const dayNumber = parseInt(date.split('-')[2], 10);
+    const dayNumber = Number.parseInt(date.split('-')[2], 10);
 
-    // 스타일 결정
     const isHolyday = !!holyday;
     const isSunday = dayOfWeek === 0;
     const isSaturday = dayOfWeek === 6;
@@ -24,10 +34,12 @@ export function CalendarCell({ day, onClick }: CalendarCellProps) {
     const attendanceRate = attendance.total > 0 ? Math.round((attendance.present / attendance.total) * 100) : 0;
 
     return (
-        <div
+        <button
+            type="button"
             onClick={() => onClick?.(date)}
+            onKeyDown={(e) => e.key === 'Enter' && onClick?.(date)}
             className={cn(
-                'group relative h-24 cursor-pointer p-2 transition-all hover:bg-accent/50 sm:h-28 sm:p-3',
+                'group relative h-24 w-full cursor-pointer p-2 text-left transition-all hover:bg-accent/50 sm:h-28 sm:p-3',
                 isHolyday && 'bg-red-50/80 hover:bg-red-100/80',
                 !isHolyday && isSunday && 'bg-rose-50/40',
                 !isHolyday && isSaturday && 'bg-blue-50/40'
@@ -49,24 +61,17 @@ export function CalendarCell({ day, onClick }: CalendarCellProps) {
             {/* 출석 현황 */}
             {attendance.total > 0 && (
                 <div className="mt-1 space-y-1">
-                    {/* 출석률 바 */}
                     <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                         <div
                             className={cn(
                                 'h-full rounded-full transition-all',
-                                isFullAttendance ? 'bg-green-500' : hasAttendance ? 'bg-amber-500' : 'bg-muted'
+                                getBarColor(isFullAttendance, hasAttendance)
                             )}
                             style={{ width: `${attendanceRate}%` }}
                         />
                     </div>
-                    {/* 출석 인원 */}
                     <div
-                        className={cn(
-                            'text-center text-xs font-medium',
-                            isFullAttendance && 'text-green-600',
-                            !isFullAttendance && hasAttendance && 'text-amber-600',
-                            !hasAttendance && 'text-muted-foreground'
-                        )}
+                        className={cn('text-center text-xs font-medium', getTextColor(isFullAttendance, hasAttendance))}
                     >
                         {attendance.present}/{attendance.total}
                     </div>
@@ -79,6 +84,6 @@ export function CalendarCell({ day, onClick }: CalendarCellProps) {
                     {holyday}
                 </div>
             )}
-        </div>
+        </button>
     );
 }

--- a/apps/web/src/pages/attendance/CalendarGrid.tsx
+++ b/apps/web/src/pages/attendance/CalendarGrid.tsx
@@ -3,6 +3,12 @@ import type { CalendarDay } from '@school/trpc';
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
+const getWeekdayColor = (index: number): string => {
+    if (index === 0) return 'text-red-500';
+    if (index === 6) return 'text-blue-500';
+    return 'text-foreground';
+};
+
 interface CalendarGridProps {
     year: number;
     month: number;
@@ -60,12 +66,7 @@ export function CalendarGrid({ year, month, days, onDateClick }: CalendarGridPro
             {/* 요일 헤더 */}
             <div className="grid grid-cols-7 bg-muted/60">
                 {WEEKDAYS.map((day, index) => (
-                    <div
-                        key={day}
-                        className={`py-3 text-center text-sm font-semibold ${
-                            index === 0 ? 'text-red-500' : index === 6 ? 'text-blue-500' : 'text-foreground'
-                        }`}
-                    >
+                    <div key={day} className={`py-3 text-center text-sm font-semibold ${getWeekdayColor(index)}`}>
                         {day}
                     </div>
                 ))}
@@ -74,7 +75,7 @@ export function CalendarGrid({ year, month, days, onDateClick }: CalendarGridPro
             {/* 달력 그리드 */}
             <div className="divide-y">
                 {grid.map((week, weekIndex) => (
-                    <div key={weekIndex} className="grid grid-cols-7 divide-x">
+                    <div key={week[0]?.date ?? `week-${weekIndex}`} className="grid grid-cols-7 divide-x">
                         {week.map((day, dayIndex) => (
                             <CalendarCell
                                 key={day?.date ?? `empty-${weekIndex}-${dayIndex}`}

--- a/apps/web/src/pages/attendance/CalendarPage.tsx
+++ b/apps/web/src/pages/attendance/CalendarPage.tsx
@@ -145,25 +145,28 @@ export function CalendarPage() {
                 </Card>
 
                 {/* 달력 영역 */}
-                {!selectedGroupId ? (
+                {!selectedGroupId && (
                     <Card>
                         <CardContent className="flex h-96 items-center justify-center">
                             <p className="text-lg text-muted-foreground">학년을 선택해주세요.</p>
                         </CardContent>
                     </Card>
-                ) : calendarLoading ? (
+                )}
+                {selectedGroupId && calendarLoading && (
                     <Card>
                         <CardContent className="flex h-96 items-center justify-center">
                             <LoadingSpinner />
                         </CardContent>
                     </Card>
-                ) : !calendarData ? (
+                )}
+                {selectedGroupId && !calendarLoading && !calendarData && (
                     <Card>
                         <CardContent className="flex h-96 items-center justify-center">
                             <p className="text-lg text-muted-foreground">데이터를 불러올 수 없습니다.</p>
                         </CardContent>
                     </Card>
-                ) : (
+                )}
+                {selectedGroupId && !calendarLoading && calendarData && (
                     <Card>
                         <CardHeader className="pb-4">
                             <CalendarHeader

--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -34,17 +34,6 @@ export function SignupPage() {
         analytics.trackPrivacyConsentShown('signup');
     }, []);
 
-    // 이미 로그인된 경우 대시보드로 리다이렉트
-    if (isAuthenticated && !isAuthLoading) {
-        return <Navigate to="/" replace />;
-    }
-
-    // ID 입력 시 소문자로 변환
-    const handleNameChange = (value: string) => {
-        setName(value.toLowerCase());
-        setIdCheckResult(null); // ID 변경 시 중복 확인 초기화
-    };
-
     // ID 중복 확인
     const handleCheckId = useCallback(async () => {
         if (name.length < 4) {
@@ -74,6 +63,17 @@ export function SignupPage() {
             setIsCheckingId(false);
         }
     }, [name, utils.auth.checkId]);
+
+    // 이미 로그인된 경우 대시보드로 리다이렉트
+    if (isAuthenticated && !isAuthLoading) {
+        return <Navigate to="/" replace />;
+    }
+
+    // ID 입력 시 소문자로 변환
+    const handleNameChange = (value: string) => {
+        setName(value.toLowerCase());
+        setIdCheckResult(null); // ID 변경 시 중복 확인 초기화
+    };
 
     // 폼 유효성 검사
     const isFormValid = () => {

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -75,18 +75,14 @@ function OnboardingChecklist({
                     return (
                         <li key={item.step}>
                             <Card
-                                className={`flex items-center gap-4 p-4 ${
-                                    isCurrent ? 'border-primary' : isCompleted ? 'bg-muted' : ''
-                                }`}
+                                className={`flex items-center gap-4 p-4 ${isCurrent ? 'border-primary' : ''}${!isCurrent && isCompleted ? ' bg-muted' : ''}`}
                             >
                                 {/* 아이콘/번호 */}
                                 <div
                                     className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
-                                        isCompleted
+                                        isCompleted || isCurrent
                                             ? 'bg-primary text-primary-foreground'
-                                            : isCurrent
-                                              ? 'bg-primary text-primary-foreground'
-                                              : 'bg-muted text-muted-foreground'
+                                            : 'bg-muted text-muted-foreground'
                                     }`}
                                 >
                                     {isCompleted ? (
@@ -300,11 +296,9 @@ export function DashboardPage() {
         return (
             <MainLayout title={`안녕하세요, ${account?.name}님!`}>
                 <div className="flex justify-center p-8">
-                    <div
-                        className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
-                        role="status"
-                        aria-label="로딩 중"
-                    />
+                    <output aria-label="로딩 중">
+                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+                    </output>
                 </div>
             </MainLayout>
         );

--- a/apps/web/src/pages/dashboard/GenderDistributionChart.tsx
+++ b/apps/web/src/pages/dashboard/GenderDistributionChart.tsx
@@ -11,6 +11,64 @@ interface GenderDistributionChartProps {
 
 const COLORS = ['#3b82f6', '#ec4899', '#9ca3af'];
 
+function GenderContent({
+    chartData,
+    totalStudents,
+    isLoading,
+    error,
+}: {
+    chartData: { name: string; value: number; rate: number }[];
+    totalStudents: number;
+    isLoading: boolean;
+    error?: boolean;
+}) {
+    if (isLoading) {
+        return (
+            <div className="flex h-[200px] items-center justify-center">
+                <LoadingSpinner />
+            </div>
+        );
+    }
+    if (error) return <p className="text-sm text-destructive">데이터 로드 실패</p>;
+    if (chartData.length > 0) {
+        return (
+            <div className="flex flex-col items-center">
+                <ResponsiveContainer width="100%" height={180}>
+                    <PieChart>
+                        <Pie
+                            data={chartData}
+                            cx="50%"
+                            cy="50%"
+                            innerRadius={40}
+                            outerRadius={70}
+                            paddingAngle={2}
+                            dataKey="value"
+                        >
+                            {chartData.map((entry, index) => (
+                                <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
+                            ))}
+                        </Pie>
+                        <Tooltip
+                            formatter={(value, _name, props) => [
+                                `${value}명 (${props.payload.rate}%)`,
+                                props.payload.name,
+                            ]}
+                        />
+                        <Legend
+                            formatter={(value) => {
+                                const item = chartData.find((d) => d.name === value);
+                                return `${value}: ${item?.value ?? 0}명`;
+                            }}
+                        />
+                    </PieChart>
+                </ResponsiveContainer>
+                <p className="text-sm text-muted-foreground">총 {totalStudents}명</p>
+            </div>
+        );
+    }
+    return <p className="text-sm text-muted-foreground">데이터 없음</p>;
+}
+
 export function GenderDistributionChart({ data, isLoading, error }: GenderDistributionChartProps) {
     const chartData = data
         ? [
@@ -28,48 +86,12 @@ export function GenderDistributionChart({ data, isLoading, error }: GenderDistri
                 <CardTitle className="text-base">성별 분포</CardTitle>
             </CardHeader>
             <CardContent>
-                {isLoading ? (
-                    <div className="flex h-[200px] items-center justify-center">
-                        <LoadingSpinner />
-                    </div>
-                ) : error ? (
-                    <p className="text-sm text-destructive">데이터 로드 실패</p>
-                ) : chartData.length > 0 ? (
-                    <div className="flex flex-col items-center">
-                        <ResponsiveContainer width="100%" height={180}>
-                            <PieChart>
-                                <Pie
-                                    data={chartData}
-                                    cx="50%"
-                                    cy="50%"
-                                    innerRadius={40}
-                                    outerRadius={70}
-                                    paddingAngle={2}
-                                    dataKey="value"
-                                >
-                                    {chartData.map((_, index) => (
-                                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                    ))}
-                                </Pie>
-                                <Tooltip
-                                    formatter={(value, _name, props) => [
-                                        `${value}명 (${props.payload.rate}%)`,
-                                        props.payload.name,
-                                    ]}
-                                />
-                                <Legend
-                                    formatter={(value) => {
-                                        const item = chartData.find((d) => d.name === value);
-                                        return `${value}: ${item?.value ?? 0}명`;
-                                    }}
-                                />
-                            </PieChart>
-                        </ResponsiveContainer>
-                        <p className="text-sm text-muted-foreground">총 {totalStudents}명</p>
-                    </div>
-                ) : (
-                    <p className="text-sm text-muted-foreground">데이터 없음</p>
-                )}
+                <GenderContent
+                    chartData={chartData}
+                    totalStudents={totalStudents}
+                    isLoading={isLoading}
+                    error={error}
+                />
             </CardContent>
         </Card>
     );

--- a/apps/web/src/pages/dashboard/GroupStatisticsTable.tsx
+++ b/apps/web/src/pages/dashboard/GroupStatisticsTable.tsx
@@ -54,6 +54,65 @@ interface GroupStatisticsTableProps {
     error?: boolean;
 }
 
+function GroupStatisticsContent({ data, isLoading, error }: GroupStatisticsTableProps) {
+    if (isLoading) {
+        return (
+            <div className="flex h-[200px] items-center justify-center">
+                <LoadingSpinner />
+            </div>
+        );
+    }
+    if (error) return <p className="text-sm text-destructive">데이터 로드 실패</p>;
+    if (data && data.groups.length > 0) {
+        return (
+            <div className="overflow-x-auto -mx-6">
+                <Table className="min-w-[600px]">
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="whitespace-nowrap">학년명</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">인원</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">주간 출석률</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">월간 출석률</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">연간 출석률</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">주간 평균</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">월간 평균</TableHead>
+                            <TableHead className="whitespace-nowrap text-center">연간 평균</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {data.groups.map((group) => (
+                            <TableRow key={group.groupId}>
+                                <TableCell className="font-medium">{group.groupName}</TableCell>
+                                <TableCell className="text-center tabular-nums">{group.totalStudents}명</TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.weekly.attendanceRate}%
+                                </TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.monthly.attendanceRate}%
+                                </TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.yearly.attendanceRate}%
+                                </TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.weekly.avgAttendance}명
+                                </TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.monthly.avgAttendance}명
+                                </TableCell>
+                                <TableCell className="text-center tabular-nums">
+                                    {group.yearly.avgAttendance}명
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                        <TotalRow groups={data.groups} />
+                    </TableBody>
+                </Table>
+            </div>
+        );
+    }
+    return <p className="text-sm text-muted-foreground">데이터 없음</p>;
+}
+
 export function GroupStatisticsTable({ data, isLoading, error }: GroupStatisticsTableProps) {
     return (
         <Card>
@@ -61,61 +120,7 @@ export function GroupStatisticsTable({ data, isLoading, error }: GroupStatistics
                 <CardTitle className="text-base">학년별 통계</CardTitle>
             </CardHeader>
             <CardContent>
-                {isLoading ? (
-                    <div className="flex h-[200px] items-center justify-center">
-                        <LoadingSpinner />
-                    </div>
-                ) : error ? (
-                    <p className="text-sm text-destructive">데이터 로드 실패</p>
-                ) : data && data.groups.length > 0 ? (
-                    <div className="overflow-x-auto -mx-6">
-                        <Table className="min-w-[600px]">
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead className="whitespace-nowrap">학년명</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">인원</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">주간 출석률</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">월간 출석률</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">연간 출석률</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">주간 평균</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">월간 평균</TableHead>
-                                    <TableHead className="whitespace-nowrap text-center">연간 평균</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {data.groups.map((group) => (
-                                    <TableRow key={group.groupId}>
-                                        <TableCell className="font-medium">{group.groupName}</TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.totalStudents}명
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.weekly.attendanceRate}%
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.monthly.attendanceRate}%
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.yearly.attendanceRate}%
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.weekly.avgAttendance}명
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.monthly.avgAttendance}명
-                                        </TableCell>
-                                        <TableCell className="text-center tabular-nums">
-                                            {group.yearly.avgAttendance}명
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                                <TotalRow groups={data.groups} />
-                            </TableBody>
-                        </Table>
-                    </div>
-                ) : (
-                    <p className="text-sm text-muted-foreground">데이터 없음</p>
-                )}
+                <GroupStatisticsContent data={data} isLoading={isLoading} error={error} />
             </CardContent>
         </Card>
     );

--- a/apps/web/src/pages/dashboard/PatronFeastCard.tsx
+++ b/apps/web/src/pages/dashboard/PatronFeastCard.tsx
@@ -4,6 +4,40 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { analytics } from '~/lib/analytics';
 import { trpc } from '~/lib/trpc';
 
+function PatronFeastContent({
+    data,
+    isLoading,
+}: {
+    data?: { students: { societyName: string; catholicName: string; baptizedAt: string }[] };
+    isLoading: boolean;
+}) {
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center p-4">
+                <LoadingSpinner />
+            </div>
+        );
+    }
+    if (data && data.students.length > 0) {
+        return (
+            <ul className="space-y-2">
+                {data.students.map((student) => {
+                    const mmdd = student.baptizedAt.slice(5);
+                    return (
+                        <li
+                            key={`${student.societyName}-${student.catholicName}-${student.baptizedAt}`}
+                            className="text-sm"
+                        >
+                            {student.societyName} · {student.catholicName} · {mmdd}
+                        </li>
+                    );
+                })}
+            </ul>
+        );
+    }
+    return <p className="text-sm text-muted-foreground">이달의 축일자가 없습니다</p>;
+}
+
 export function PatronFeastCard() {
     const currentMonth = new Date().getMonth() + 1;
     const { data, isLoading, isError } = trpc.student.feastDayList.useQuery(
@@ -29,27 +63,7 @@ export function PatronFeastCard() {
                 <CardTitle className="text-base">이달의 축일자</CardTitle>
             </CardHeader>
             <CardContent>
-                {isLoading ? (
-                    <div className="flex items-center justify-center p-4">
-                        <LoadingSpinner />
-                    </div>
-                ) : data && data.students.length > 0 ? (
-                    <ul className="space-y-2">
-                        {data.students.map((student) => {
-                            const mmdd = student.baptizedAt.slice(5);
-                            return (
-                                <li
-                                    key={`${student.societyName}-${student.catholicName}-${student.baptizedAt}`}
-                                    className="text-sm"
-                                >
-                                    {student.societyName} · {student.catholicName} · {mmdd}
-                                </li>
-                            );
-                        })}
-                    </ul>
-                ) : (
-                    <p className="text-sm text-muted-foreground">이달의 축일자가 없습니다</p>
-                )}
+                <PatronFeastContent data={data} isLoading={isLoading} />
             </CardContent>
         </Card>
     );

--- a/apps/web/src/pages/dashboard/TopRankingCard.tsx
+++ b/apps/web/src/pages/dashboard/TopRankingCard.tsx
@@ -16,6 +16,39 @@ interface TopRankingCardProps {
     error?: boolean;
 }
 
+function RankingContent({ items, isLoading, error }: Omit<TopRankingCardProps, 'title'>) {
+    if (isLoading) {
+        return (
+            <div className="flex h-[150px] items-center justify-center">
+                <LoadingSpinner />
+            </div>
+        );
+    }
+    if (error) return <p className="text-sm text-destructive">데이터 로드 실패</p>;
+    if (items.length > 0) {
+        return (
+            <div className="space-y-2">
+                {items.map((item, index) => (
+                    <div key={item.id} className="flex items-center justify-between">
+                        <span className="truncate">
+                            <span className="mr-2 font-medium text-muted-foreground">{index + 1}.</span>
+                            {item.name}
+                            {item.subText && (
+                                <span className="ml-1 text-sm text-muted-foreground">({item.subText})</span>
+                            )}
+                        </span>
+                        <span className="ml-2 whitespace-nowrap font-medium">
+                            {item.value}
+                            {item.valueSuffix}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+    return <p className="text-sm text-muted-foreground">데이터 없음</p>;
+}
+
 export function TopRankingCard({ title, items, isLoading, error }: TopRankingCardProps) {
     return (
         <Card>
@@ -23,33 +56,7 @@ export function TopRankingCard({ title, items, isLoading, error }: TopRankingCar
                 <CardTitle className="text-base">{title}</CardTitle>
             </CardHeader>
             <CardContent>
-                {isLoading ? (
-                    <div className="flex h-[150px] items-center justify-center">
-                        <LoadingSpinner />
-                    </div>
-                ) : error ? (
-                    <p className="text-sm text-destructive">데이터 로드 실패</p>
-                ) : items.length > 0 ? (
-                    <div className="space-y-2">
-                        {items.map((item, index) => (
-                            <div key={item.id} className="flex items-center justify-between">
-                                <span className="truncate">
-                                    <span className="mr-2 font-medium text-muted-foreground">{index + 1}.</span>
-                                    {item.name}
-                                    {item.subText && (
-                                        <span className="ml-1 text-sm text-muted-foreground">({item.subText})</span>
-                                    )}
-                                </span>
-                                <span className="ml-2 whitespace-nowrap font-medium">
-                                    {item.value}
-                                    {item.valueSuffix}
-                                </span>
-                            </div>
-                        ))}
-                    </div>
-                ) : (
-                    <p className="text-sm text-muted-foreground">데이터 없음</p>
-                )}
+                <RankingContent items={items} isLoading={isLoading} error={error} />
             </CardContent>
         </Card>
     );

--- a/apps/web/src/pages/group/GroupDetailPage.tsx
+++ b/apps/web/src/pages/group/GroupDetailPage.tsx
@@ -115,8 +115,9 @@ export function GroupDetailPage() {
                                         </Button>
                                     </div>
                                 ) : (
-                                    <div
-                                        className="cursor-pointer rounded-md p-1 hover:bg-muted/50"
+                                    <button
+                                        type="button"
+                                        className="w-full cursor-pointer rounded-md p-1 text-left hover:bg-muted/50"
                                         onClick={() => group && setIsEditing(true)}
                                         title="클릭하여 수정"
                                     >
@@ -124,7 +125,7 @@ export function GroupDetailPage() {
                                             {isLoading ? '로딩 중...' : group?.name}
                                         </CardTitle>
                                         <CardDescription>학년 정보 (클릭하여 수정)</CardDescription>
-                                    </div>
+                                    </button>
                                 )}
                             </div>
                             <div className="flex gap-3">

--- a/apps/web/src/pages/group/GroupListPage.tsx
+++ b/apps/web/src/pages/group/GroupListPage.tsx
@@ -37,13 +37,8 @@ export function GroupListPage() {
         }
     };
 
-    const handleSelectAll = (checked: boolean) => {
-        if (checked) {
-            setSelectedIds(new Set(groups.map((g) => g.id)));
-        } else {
-            setSelectedIds(new Set());
-        }
-    };
+    const selectAll = () => setSelectedIds(new Set(groups.map((g) => g.id)));
+    const deselectAll = () => setSelectedIds(new Set());
 
     const handleSelectOne = (id: string, checked: boolean) => {
         const newSet = new Set(selectedIds);
@@ -98,7 +93,10 @@ export function GroupListPage() {
                                     ref={(el) => {
                                         if (el) el.indeterminate = isSomeSelected;
                                     }}
-                                    onCheckedChange={handleSelectAll}
+                                    onCheckedChange={(checked) => {
+                                        if (checked) selectAll();
+                                        else deselectAll();
+                                    }}
                                     aria-label="전체 선택"
                                 />
                             </TableHead>

--- a/apps/web/src/pages/landing/InteractiveDemo.tsx
+++ b/apps/web/src/pages/landing/InteractiveDemo.tsx
@@ -24,7 +24,7 @@ const buildDemoCalendar = (year: number, month: number) => {
     const firstDay = new Date(year, month, 1).getDay();
     const daysInMonth = new Date(year, month + 1, 0).getDate();
     const weeks: (number | null)[][] = [];
-    let week: (number | null)[] = Array(firstDay).fill(null);
+    let week: (number | null)[] = new Array(firstDay).fill(null);
 
     for (let d = 1; d <= daysInMonth; d++) {
         week.push(d);
@@ -41,6 +41,12 @@ const buildDemoCalendar = (year: number, month: number) => {
 };
 
 type DayAttendance = Record<number, { mass: boolean; catechism: boolean }>;
+
+const getSymbolColor = (symbol: string): string => {
+    if (symbol === '◎') return 'text-green-600';
+    if (symbol === '-') return 'text-muted-foreground/40';
+    return 'text-yellow-600';
+};
 
 // 날짜별 출석 현황 계산
 const countPresent = (att: DayAttendance) => Object.values(att).filter((a) => a.mass || a.catechism).length;
@@ -159,6 +165,7 @@ export function InteractiveDemo() {
                 {/* 날짜 그리드 */}
                 <div className="grid grid-cols-7 gap-0">
                     {weeks.flat().map((day, i) => {
+                        const weekIndex = Math.floor(i / 7);
                         const dayOfWeek = i % 7;
                         const isSunday = dayOfWeek === 0;
                         const isSaturday = dayOfWeek === 6;
@@ -168,12 +175,12 @@ export function InteractiveDemo() {
                         const dayPresentCount = dayData ? countPresent(dayData) : 0;
 
                         if (day === null) {
-                            return <div key={i} className="h-12" />;
+                            return <div key={`empty-w${weekIndex}-d${dayOfWeek}`} className="h-12" />;
                         }
 
                         return (
                             <button
-                                key={i}
+                                key={`day-${day}`}
                                 type="button"
                                 onClick={() => handleDateClick(day)}
                                 className={cn(
@@ -271,11 +278,7 @@ export function InteractiveDemo() {
                                             <span
                                                 className={cn(
                                                     'text-center text-base font-bold',
-                                                    symbol === '◎'
-                                                        ? 'text-green-600'
-                                                        : symbol === '-'
-                                                          ? 'text-muted-foreground/40'
-                                                          : 'text-yellow-600'
+                                                    getSymbolColor(symbol)
                                                 )}
                                             >
                                                 {symbol}

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -229,7 +229,7 @@ export function LandingPage() {
                             }}
                         >
                             {FAQ_ITEMS.map((item, index) => (
-                                <AccordionItem key={index} value={String(index)}>
+                                <AccordionItem key={item.question} value={String(index)}>
                                     <AccordionTrigger>{item.question}</AccordionTrigger>
                                     <AccordionContent>
                                         <p className="text-muted-foreground">{item.answer}</p>

--- a/apps/web/src/pages/student/EditableField.tsx
+++ b/apps/web/src/pages/student/EditableField.tsx
@@ -55,7 +55,7 @@ export function EditableField({
                 {label}
             </dt>
             <dd className="flex-1 text-base sm:text-xl">
-                {isEditing ? (
+                {isEditing && (
                     <div className="flex flex-col gap-2">
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                             <div className="flex-1">{inputElement}</div>
@@ -70,14 +70,17 @@ export function EditableField({
                         </div>
                         {hint && <p className="text-sm text-muted-foreground sm:text-base">{hint}</p>}
                     </div>
-                ) : (
-                    <span
-                        className={`rounded px-2 py-1 ${disabled ? '' : 'cursor-pointer hover:bg-muted/50'}`}
-                        onClick={() => !disabled && startEdit()}
-                        title={disabled ? undefined : '클릭하여 수정'}
+                )}
+                {!isEditing && disabled && <span className="rounded px-2 py-1">{displayValue ?? (value || '-')}</span>}
+                {!isEditing && !disabled && (
+                    <button
+                        type="button"
+                        className="cursor-pointer rounded px-2 py-1 hover:bg-muted/50"
+                        onClick={startEdit}
+                        title="클릭하여 수정"
                     >
                         {displayValue ?? (value || '-')}
-                    </span>
+                    </button>
                 )}
             </dd>
         </div>

--- a/apps/web/src/pages/student/StudentDetailPage.tsx
+++ b/apps/web/src/pages/student/StudentDetailPage.tsx
@@ -21,6 +21,8 @@ export function StudentDetailPage() {
 
     const isDeleted = !!student?.deletedAt;
 
+    const parseOptionalInt = (v: string): number | undefined => (v ? Number.parseInt(v) : undefined);
+
     const handleUpdate = async (field: string, value: string) => {
         if (!id || !student) return;
         try {
@@ -30,8 +32,8 @@ export function StudentDetailPage() {
                 catholicName: field === 'catholicName' ? value || undefined : student.catholicName,
                 gender:
                     field === 'gender' ? (value as 'M' | 'F' | undefined) : (student.gender as 'M' | 'F' | undefined),
-                age: field === 'age' ? (value ? parseInt(value) : undefined) : student.age,
-                contact: field === 'contact' ? (value ? parseInt(value) : undefined) : student.contact,
+                age: field === 'age' ? parseOptionalInt(value) : student.age,
+                contact: field === 'contact' ? parseOptionalInt(value) : student.contact,
                 groupId: field === 'groupId' ? value : student.groupId,
                 baptizedAt: field === 'baptizedAt' ? value || undefined : student.baptizedAt,
                 description: field === 'description' ? value || undefined : student.description,
@@ -48,7 +50,12 @@ export function StudentDetailPage() {
         : '-';
 
     // 성별 표시값 변환
-    const genderDisplay = student?.gender === 'M' ? '남' : student?.gender === 'F' ? '여' : '-';
+    const getGenderDisplay = (gender?: string | null): string => {
+        if (gender === 'M') return '남';
+        if (gender === 'F') return '여';
+        return '-';
+    };
+    const genderDisplay = getGenderDisplay(student?.gender);
 
     // 그룹 이름 찾기
     const groupName = groups.find((g) => g.id === student?.groupId)?.name ?? student?.groupId ?? '';
@@ -169,7 +176,7 @@ export function StudentDetailPage() {
                                     renderInput={({ value, onChange, onKeyDown }) => (
                                         <Input
                                             value={value}
-                                            onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ''))}
+                                            onChange={(e) => onChange(e.target.value.replaceAll(/[^0-9]/, ''))}
                                             onKeyDown={onKeyDown}
                                             placeholder="01012345678"
                                             autoFocus

--- a/apps/web/src/pages/student/StudentForm.tsx
+++ b/apps/web/src/pages/student/StudentForm.tsx
@@ -184,7 +184,7 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
                             className="h-12 text-lg"
                             value={formData.age ?? ''}
                             onChange={(e) =>
-                                handleChange('age', e.target.value ? parseInt(e.target.value, 10) : undefined)
+                                handleChange('age', e.target.value ? Number.parseInt(e.target.value, 10) : undefined)
                             }
                             placeholder="나이를 입력하세요…"
                             disabled={isSubmitting}
@@ -201,7 +201,10 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
                             className="h-12 text-lg"
                             value={formData.contact ?? ''}
                             onChange={(e) =>
-                                handleChange('contact', e.target.value ? parseInt(e.target.value, 10) : undefined)
+                                handleChange(
+                                    'contact',
+                                    e.target.value ? Number.parseInt(e.target.value, 10) : undefined
+                                )
                             }
                             placeholder="연락처를 입력하세요 (숫자만)…"
                             disabled={isSubmitting}
@@ -217,7 +220,7 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
                             className="h-12 text-lg"
                             value={formData.baptizedAt ?? ''}
                             onChange={(e) => {
-                                const digits = e.target.value.replace(/\D/g, '');
+                                const digits = e.target.value.replaceAll(/\D/, '');
                                 let formatted = '';
                                 if (digits.length >= 2) {
                                     formatted = digits.slice(0, 2) + '/' + digits.slice(2, 4);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "lint": "turbo run lint",
         "lint:fix": "turbo run lint -- --fix",
         "prettier": "prettier --check \"**/*.ts\"",
-        "prettier:fix": "prettier --write \"**/*.ts\""
+        "prettier:fix": "prettier --write \"**/*.ts\"",
+        "sonar": "npx sonar-scanner"
     },
     "author": "dc-choi",
     "license": "",

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -156,6 +156,18 @@ export const getWeekRangeInMonth = (
 };
 
 /**
+ * 졸업 필터 기준일을 계산한다.
+ *
+ * 주/월/연 단위에 따라 조회 기간 시작일을 반환.
+ * 통계 유스케이스에서 졸업생 필터링에 사용된다.
+ */
+export const getGraduationCutoff = (year: number, month?: number, week?: number): Date => {
+    if (month && week) return getWeekRangeInMonth(year, month, week).startDate;
+    if (month) return new Date(year, month - 1, 1);
+    return new Date(year, 0, 1);
+};
+
+/**
  * 부활 대축일을 계산한다. (Anonymous Gregorian Algorithm)
  *
  * 부활 대축일 정의: 춘분(3월 21일) 이후 첫 보름달 다음 일요일

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -41,7 +41,7 @@ export const formatDateISO = (date: Date): string => {
 export const formatDateKR = (date: Date | string | null | undefined, fallback = '-'): string => {
     if (!date) return fallback;
     const d = typeof date === 'string' ? new Date(date) : date;
-    if (isNaN(d.getTime())) return fallback;
+    if (Number.isNaN(d.getTime())) return fallback;
     return d.toLocaleDateString('ko-KR');
 };
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -11,6 +11,7 @@ export {
     getLastSundayOf,
     getWeeksInMonth,
     getWeekRangeInMonth,
+    getGraduationCutoff,
     calculateEaster,
 } from './date.js';
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=dc-choi_school-manage-back
+sonar.projectName=school-manage-back
+sonar.organization=dc-choi
+sonar.host.url=https://sonarcloud.io
+sonar.projectVersion=1.0
+
+# Source code (monorepo)
+sonar.sources=apps/api/src,apps/web/src,packages/trpc/src,packages/utils/src
+sonar.exclusions=**/*.spec.ts,**/*.test.ts,**/node_modules/**,**/dist/**,**/logs/**
+
+# TypeScript
+sonar.typescript.node=node
+sonar.typescript.tsconfigPaths=apps/api/tsconfig.json,apps/web/tsconfig.json,packages/trpc/tsconfig.json,packages/utils/tsconfig.json


### PR DESCRIPTION
## Summary

SonarCloud 분석을 통해 코드 품질을 전반적으로 개선했습니다.

- **Bug**: 4개 → 0개 (React Hooks, a11y 접근성)
- **CRITICAL/MAJOR 코드스멜**: 27개 → 0개 (중첩 삼항, 배열 인덱스 키 등)
- **Reliability 이슈**: 14개 → 0개 (Number.parseInt, Number.isNaN 등)
- **전체 코드스멜**: 150개 → 89개 (26% 감소)
- **구현**: `getGraduationCutoff` 추출, 컴포넌트 분리, 헬퍼 함수 분리

## Test plan

- [x] 타입체크 통과 (`pnpm typecheck`)
- [x] SonarCloud 분석 재실행 (커밋 후 메트릭 검증)
- [x] 모든 변경사항 비활성화/추가 기능 없음 (리팩토링만)

🤖 Generated with Claude Code