### PR TITLE
fix: 대시보드 통계 미래 날짜 제한

### DIFF
--- a/apps/api/src/domains/statistics/application/get-attendance-rate.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-attendance-rate.usecase.ts
@@ -5,6 +5,7 @@
  */
 import type { AttendanceRateOutput, StatisticsInput as StatisticsSchemaInput } from '@school/trpc';
 import {
+    clampToToday,
     countSundays,
     formatDateCompact,
     getThisWeekSaturday,
@@ -144,17 +145,17 @@ export class GetAttendanceRateUseCase {
             if (month) {
                 return {
                     startDate: new Date(year, month - 1, 1),
-                    endDate: new Date(year, month, 0),
+                    endDate: clampToToday(new Date(year, month, 0)),
                 };
             }
             const startDate = new Date(year, now.getMonth(), 1);
-            const endDate = new Date(year, now.getMonth() + 1, 0);
+            const endDate = clampToToday(new Date(year, now.getMonth() + 1, 0));
             return { startDate, endDate };
         }
 
         return {
             startDate: new Date(year, 0, 1),
-            endDate: new Date(year, 11, 31),
+            endDate: clampToToday(new Date(year, 11, 31)),
         };
     }
 }

--- a/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
@@ -5,8 +5,8 @@
  */
 import type { GenderDistributionOutput, StatisticsInput as StatisticsSchemaInput } from '@school/trpc';
 import {
+    clampToToday,
     countSundays,
-    countSundaysInYear,
     formatDateCompact,
     getGraduationCutoff,
     getWeekRangeInMonth,
@@ -133,7 +133,7 @@ export class GetByGenderUseCase {
 
         if (month) {
             const startDate = new Date(year, month - 1, 1);
-            const endDate = new Date(year, month, 0);
+            const endDate = clampToToday(new Date(year, month, 0));
             return {
                 startDateStr: formatDateCompact(startDate),
                 endDateStr: formatDateCompact(endDate),
@@ -142,11 +142,11 @@ export class GetByGenderUseCase {
         }
 
         const startDate = new Date(year, 0, 1);
-        const endDate = new Date(year, 11, 31);
+        const endDate = clampToToday(new Date(year, 11, 31));
         return {
             startDateStr: formatDateCompact(startDate),
             endDateStr: formatDateCompact(endDate),
-            totalDays: countSundaysInYear(year),
+            totalDays: countSundays(startDate, endDate),
         };
     }
 }

--- a/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
@@ -5,6 +5,7 @@
  */
 import type { GroupStatisticsOutput, StatisticsInput as StatisticsSchemaInput } from '@school/trpc';
 import {
+    clampToToday,
     countSundays,
     formatDateCompact,
     getGraduationCutoff,
@@ -178,20 +179,20 @@ export class GetGroupStatisticsUseCase {
         if (month) {
             return {
                 startDate: new Date(year, month - 1, 1),
-                endDate: new Date(year, month, 0),
+                endDate: clampToToday(new Date(year, month, 0)),
             };
         }
         const now = new Date();
         return {
             startDate: new Date(year, now.getMonth(), 1),
-            endDate: new Date(year, now.getMonth() + 1, 0),
+            endDate: clampToToday(new Date(year, now.getMonth() + 1, 0)),
         };
     }
 
     private getYearlyRange(year: number): DateRange {
         return {
             startDate: new Date(year, 0, 1),
-            endDate: new Date(year, 11, 31),
+            endDate: clampToToday(new Date(year, 11, 31)),
         };
     }
 }

--- a/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
@@ -5,8 +5,8 @@
  */
 import type { TopGroupsOutput, TopStatisticsInput as TopStatisticsSchemaInput } from '@school/trpc';
 import {
+    clampToToday,
     countSundays,
-    countSundaysInYear,
     formatDateCompact,
     getGraduationCutoff,
     getWeekRangeInMonth,
@@ -127,7 +127,7 @@ export class GetTopGroupsUseCase {
 
         if (month) {
             const startDate = new Date(year, month - 1, 1);
-            const endDate = new Date(year, month, 0);
+            const endDate = clampToToday(new Date(year, month, 0));
             return {
                 startDateStr: formatDateCompact(startDate),
                 endDateStr: formatDateCompact(endDate),
@@ -136,11 +136,11 @@ export class GetTopGroupsUseCase {
         }
 
         const startDate = new Date(year, 0, 1);
-        const endDate = new Date(year, 11, 31);
+        const endDate = clampToToday(new Date(year, 11, 31));
         return {
             startDateStr: formatDateCompact(startDate),
             endDateStr: formatDateCompact(endDate),
-            totalDays: countSundaysInYear(year),
+            totalDays: countSundays(startDate, endDate),
         };
     }
 }

--- a/apps/api/src/domains/statistics/application/get-top-overall.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-top-overall.usecase.ts
@@ -5,7 +5,7 @@
  */
 import { Prisma } from '@prisma/client';
 import type { TopOverallOutput, TopStatisticsInput as TopStatisticsSchemaInput } from '@school/trpc';
-import { formatDateCompact, getWeekRangeInMonth } from '@school/utils';
+import { clampToToday, formatDateCompact, getWeekRangeInMonth } from '@school/utils';
 import { getBulkGroupSnapshots, getBulkStudentSnapshots } from '~/domains/snapshot/snapshot.helper.js';
 import { database } from '~/infrastructure/database/database.js';
 
@@ -103,7 +103,7 @@ export class GetTopOverallUseCase {
 
         if (month) {
             const startDate = new Date(year, month - 1, 1);
-            const endDate = new Date(year, month, 0);
+            const endDate = clampToToday(new Date(year, month, 0));
             return {
                 startDateStr: formatDateCompact(startDate),
                 endDateStr: formatDateCompact(endDate),
@@ -111,7 +111,7 @@ export class GetTopOverallUseCase {
         }
 
         const startDate = new Date(year, 0, 1);
-        const endDate = new Date(year, 11, 31);
+        const endDate = clampToToday(new Date(year, 11, 31));
         return {
             startDateStr: formatDateCompact(startDate),
             endDateStr: formatDateCompact(endDate),

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { GroupStatisticsTable } from './GroupStatisticsTable';
 import { LiturgicalSeasonCard } from './LiturgicalSeasonCard';
 import { PatronFeastCard } from './PatronFeastCard';
 import { TopRankingCard } from './TopRankingCard';
-import { getWeeksInMonth } from '@school/utils';
+import { getNthSundayOf, getWeeksInMonth } from '@school/utils';
 import { Check } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -126,7 +126,9 @@ function OnboardingChecklist({
 
 function DashboardContent() {
     const { account } = useAuth();
-    const currentYear = new Date().getFullYear();
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
     const [selectedYear, setSelectedYear] = useState(currentYear);
     const [selectedMonth, setSelectedMonth] = useState<number | undefined>(undefined);
     const [selectedWeek, setSelectedWeek] = useState<number | undefined>(undefined);
@@ -152,24 +154,27 @@ function DashboardContent() {
     }, [currentYear]);
 
     const monthOptions = useMemo(() => {
+        const maxMonth = selectedYear === currentYear ? currentMonth : 12;
         const months = [{ value: '', label: '전체' }];
-        for (let m = 1; m <= 12; m++) {
+        for (let m = 1; m <= maxMonth; m++) {
             months.push({ value: m.toString(), label: `${m}월` });
         }
         return months;
-    }, []);
+    }, [selectedYear, currentYear, currentMonth]);
 
     const weekOptions = useMemo(() => {
         if (!selectedMonth) {
             return [{ value: '', label: '전체' }];
         }
         const weeksInMonth = getWeeksInMonth(selectedYear, selectedMonth);
+        const isCurrentMonth = selectedYear === currentYear && selectedMonth === currentMonth;
         const weeks = [{ value: '', label: '전체' }];
         for (let w = 1; w <= weeksInMonth; w++) {
+            if (isCurrentMonth && getNthSundayOf(selectedYear, selectedMonth, w) > now) break;
             weeks.push({ value: w.toString(), label: `${w}주차` });
         }
         return weeks;
-    }, [selectedYear, selectedMonth]);
+    }, [selectedYear, selectedMonth, currentYear, currentMonth, now]);
 
     const topStudentItems =
         stats.topOverall?.students.map((s) => ({

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -168,6 +168,18 @@ export const getGraduationCutoff = (year: number, month?: number, week?: number)
 };
 
 /**
+ * 종료일이 오늘 이후이면 오늘 날짜로 제한한다.
+ * 현재 연도/월의 통계에서 미래 기간을 제외하기 위해 사용.
+ */
+export const clampToToday = (endDate: Date): Date => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const end = new Date(endDate);
+    end.setHours(0, 0, 0, 0);
+    return end > today ? today : endDate;
+};
+
+/**
  * 부활 대축일을 계산한다. (Anonymous Gregorian Algorithm)
  *
  * 부활 대축일 정의: 춘분(3월 21일) 이후 첫 보름달 다음 일요일

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export {
     getWeeksInMonth,
     getWeekRangeInMonth,
     getGraduationCutoff,
+    clampToToday,
     calculateEaster,
 } from './date.js';
 


### PR DESCRIPTION
## 요약

대시보드에서 현재 시점 이후 날짜를 선택할 수 없도록 제한하고, 올해 통계 출석률 분모를 오늘까지의 일요일 수로 보정합니다.

- **프론트엔드**: 현재 연도일 때 미래 월/주 선택 차단
- **백엔드**: `clampToToday()` 유틸로 통계 endDate를 오늘로 제한 (5개 유스케이스)
- **효과**: 2026년 전체 통계 시 분모가 52주 → 오늘까지의 일요일 수로 보정되어 출석률이 정확해짐

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm test` 131개 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)