### PR TITLE
fix: 등록 모달 미등록 인원 계산에 졸업 필터 적용

### DIFF
--- a/apps/api/src/domains/student/application/list-students.usecase.ts
+++ b/apps/api/src/domains/student/application/list-students.usecase.ts
@@ -46,6 +46,9 @@ export class ListStudentsUseCase {
             ...registeredFilter,
         };
 
+        // 등록 현황 요약용 졸업 필터
+        const summaryGraduatedFilter = this.buildGraduatedFilter(input.graduated);
+
         // 학생 목록 조회 + 등록 현황 요약 (병렬)
         const [rows, count, registeredCount, totalActiveStudents] = await Promise.all([
             database.student.findMany({
@@ -73,6 +76,7 @@ export class ListStudentsUseCase {
                     student: {
                         groupId: { in: groupIds },
                         deletedAt: null,
+                        ...summaryGraduatedFilter,
                     },
                 },
             }),
@@ -81,6 +85,7 @@ export class ListStudentsUseCase {
                 where: {
                     groupId: { in: groupIds },
                     deletedAt: null,
+                    ...summaryGraduatedFilter,
                 },
             }),
         ]);


### PR DESCRIPTION
## 문제
등록 모달에서 미등록 인원이 잘못 표기되는 버그 발생. 총 인원이 31명인데 미등록 인원 수가 부정확함.

## 원인
`ListStudentsUseCase`에서 `registrationSummary` 계산 시 졸업 필터를 적용하지 않아 졸업생이 포함된 수치로 계산되고 있었음.

## 해결
`registeredCount`와 `totalActiveStudents` 쿼리에 졸업 필터(`summaryGraduatedFilter`)를 적용하여 입력 파라미터와 동일한 필터 기준으로 통계 계산.

## 검증
- typecheck: ✅
- test: ✅ (132 passed)

🤖 Generated with Claude Code