### PR TITLE
feat: 학생 연락처 입력 다양한 형식 지원

### DIFF
--- a/apps/api/src/domains/group/application/get-group-attendance.usecase.ts
+++ b/apps/api/src/domains/group/application/get-group-attendance.usecase.ts
@@ -43,7 +43,7 @@ export class GetGroupAttendanceUseCase {
                 societyName: s.societyName,
                 catholicName: s.catholicName ?? undefined,
                 age: s.age != null ? Number(s.age) : undefined,
-                contact: s.contact != null ? Number(s.contact) : undefined,
+                contact: s.contact != null ? String(s.contact) : undefined,
                 description: s.description ?? undefined,
                 groupId: String(s.groupId),
                 baptizedAt: s.baptizedAt ?? undefined,

--- a/apps/api/src/domains/group/application/get-group.usecase.ts
+++ b/apps/api/src/domains/group/application/get-group.usecase.ts
@@ -44,7 +44,7 @@ export class GetGroupUseCase {
                 societyName: student.societyName,
                 catholicName: student.catholicName ?? undefined,
                 age: student.age ? Number(student.age) : undefined,
-                contact: student.contact ? Number(student.contact) : undefined,
+                contact: student.contact ? String(student.contact) : undefined,
                 description: student.description ?? undefined,
                 groupId: String(student.groupId),
                 baptizedAt: student.baptizedAt ?? undefined,

--- a/apps/api/src/domains/student/application/create-student.usecase.ts
+++ b/apps/api/src/domains/student/application/create-student.usecase.ts
@@ -70,7 +70,7 @@ export class CreateStudentUseCase {
                 catholicName: student.catholicName ?? undefined,
                 gender: student.gender ?? undefined,
                 age: student.age != null ? Number(student.age) : undefined,
-                contact: student.contact != null ? Number(student.contact) : undefined,
+                contact: student.contact != null ? String(student.contact) : undefined,
                 description: student.description ?? undefined,
                 groupId: String(student.groupId),
                 baptizedAt: student.baptizedAt ?? undefined,

--- a/apps/api/src/domains/student/application/delete-student.usecase.ts
+++ b/apps/api/src/domains/student/application/delete-student.usecase.ts
@@ -25,7 +25,7 @@ export class DeleteStudentUseCase {
                 societyName: student.societyName,
                 catholicName: student.catholicName ?? undefined,
                 age: student.age != null ? Number(student.age) : undefined,
-                contact: student.contact != null ? Number(student.contact) : undefined,
+                contact: student.contact != null ? String(student.contact) : undefined,
                 description: student.description ?? undefined,
                 groupId: String(student.groupId),
                 baptizedAt: student.baptizedAt ?? undefined,

--- a/apps/api/src/domains/student/application/get-student.usecase.ts
+++ b/apps/api/src/domains/student/application/get-student.usecase.ts
@@ -29,7 +29,7 @@ export class GetStudentUseCase {
             catholicName: student.catholicName ?? undefined,
             gender: student.gender ?? undefined,
             age: student.age != null ? Number(student.age) : undefined,
-            contact: student.contact != null ? Number(student.contact) : undefined,
+            contact: student.contact != null ? String(student.contact) : undefined,
             description: student.description ?? undefined,
             groupId: String(student.groupId),
             baptizedAt: student.baptizedAt ?? undefined,

--- a/apps/api/src/domains/student/application/list-students.usecase.ts
+++ b/apps/api/src/domains/student/application/list-students.usecase.ts
@@ -101,7 +101,7 @@ export class ListStudentsUseCase {
                 catholicName: row.catholicName ?? undefined,
                 gender: row.gender ?? undefined,
                 age: row.age != null ? Number(row.age) : undefined,
-                contact: row.contact != null ? Number(row.contact) : undefined,
+                contact: row.contact != null ? String(row.contact) : undefined,
                 description: row.description ?? undefined,
                 groupId: String(row.groupId),
                 groupName: row.group?.name ?? '',

--- a/apps/api/src/domains/student/application/update-student.usecase.ts
+++ b/apps/api/src/domains/student/application/update-student.usecase.ts
@@ -47,7 +47,7 @@ export class UpdateStudentUseCase {
                 catholicName: student.catholicName ?? undefined,
                 gender: student.gender ?? undefined,
                 age: student.age != null ? Number(student.age) : undefined,
-                contact: student.contact != null ? Number(student.contact) : undefined,
+                contact: student.contact != null ? String(student.contact) : undefined,
                 description: student.description ?? undefined,
                 groupId: String(student.groupId),
                 baptizedAt: student.baptizedAt ?? undefined,

--- a/apps/web/src/features/student/utils/excel-import.ts
+++ b/apps/web/src/features/student/utils/excel-import.ts
@@ -21,7 +21,7 @@ export interface ParsedRow {
 export interface ValidatedRow extends ParsedRow {
     groupId: string | null;
     normalizedGender: 'M' | 'F' | null;
-    normalizedContact: number | null;
+    normalizedContact: string | null;
     normalizedAge: number | null;
     normalizedRegistered: boolean;
     status: 'success' | 'error';
@@ -77,7 +77,7 @@ export const validateRows = (rows: ParsedRow[], groups: GroupInfo[]): ValidatedR
         const errors: string[] = [];
         let groupId: string | null = null;
         let normalizedGender: 'M' | 'F' | null = null;
-        let normalizedContact: number | null = null;
+        let normalizedContact: string | null = null;
         let normalizedAge: number | null = null;
         const REGISTERED_VALUES = new Set(['O', 'o', 'ㅇ', '○']);
         const normalizedRegistered = row.registered !== null && REGISTERED_VALUES.has(row.registered);
@@ -117,7 +117,7 @@ export const validateRows = (rows: ParsedRow[], groups: GroupInfo[]): ValidatedR
         if (row.contact) {
             const digits = row.contact.replace(/\D/g, '');
             if (digits) {
-                normalizedContact = Number(digits);
+                normalizedContact = digits;
             } else {
                 errors.push('전화번호는 숫자만 입력해 주세요. 예: 01012345678');
             }

--- a/apps/web/src/pages/group/GroupDetailPage.tsx
+++ b/apps/web/src/pages/group/GroupDetailPage.tsx
@@ -9,7 +9,7 @@ import { Input } from '~/components/ui/input';
 import { useGroups } from '~/features/group';
 import { extractErrorMessage } from '~/lib/error';
 
-function formatPhoneNumber(contact: number | undefined): string {
+function formatPhoneNumber(contact: string | undefined): string {
     if (!contact) return '-';
     // 숫자로 저장되면서 앞의 0이 사라진 경우 (1012341234 → 01012341234)
     const str = String(contact).padStart(11, '0');

--- a/apps/web/src/pages/student/StudentDetailPage.tsx
+++ b/apps/web/src/pages/student/StudentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { StudentForm } from './StudentForm';
-import { formatDateKR } from '@school/utils';
+import { formatContact, formatDateKR } from '@school/utils';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { MainLayout } from '~/components/layout';
@@ -33,10 +33,7 @@ export function StudentDetailPage() {
     const isDeleted = !!student?.deletedAt;
 
     // 연락처 표시값 변환
-    const contactRaw = student?.contact ? String(student.contact).padStart(11, '0') : '';
-    const contactDisplay = contactRaw
-        ? `${contactRaw.slice(0, 3)}-${contactRaw.slice(3, 7)}-${contactRaw.slice(7)}`
-        : '-';
+    const contactDisplay = student?.contact ? formatContact(student.contact) : '-';
 
     // 성별 표시값 변환
     const getGenderDisplay = (gender?: string | null): string => {

--- a/apps/web/src/pages/student/StudentForm.tsx
+++ b/apps/web/src/pages/student/StudentForm.tsx
@@ -1,4 +1,5 @@
 import type { GroupOutput } from '@school/trpc';
+import { formatContact } from '@school/utils';
 import { type FormEvent, useState } from 'react';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
@@ -12,7 +13,7 @@ interface StudentFormData {
     catholicName?: string;
     gender?: 'M' | 'F';
     age?: number;
-    contact?: number;
+    contact?: string;
     description?: string;
     groupId: string;
     baptizedAt?: string;
@@ -46,6 +47,9 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
         groupId: initialData?.groupId ?? '',
         baptizedAt: toFeastDayFormat(initialData?.baptizedAt),
     });
+    const [contactInput, setContactInput] = useState(() =>
+        initialData?.contact ? formatContact(initialData.contact) : ''
+    );
     const [errors, setErrors] = useState<Record<string, string>>({});
 
     const handleChange = (field: keyof StudentFormData, value: string | number | undefined) => {
@@ -74,10 +78,12 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
         }
 
         try {
+            const digits = contactInput.replace(/\D/g, '');
             await onSubmit({
                 ...formData,
                 societyName: formData.societyName.trim(),
                 catholicName: formData.catholicName?.trim() || undefined,
+                contact: digits || undefined,
                 description: formData.description?.trim() || undefined,
                 baptizedAt: formData.baptizedAt?.trim() || undefined,
             });
@@ -197,16 +203,15 @@ export function StudentForm({ initialData, groups, onSubmit, onCancel, isSubmitt
                         </Label>
                         <Input
                             id="contact"
-                            type="number"
+                            type="text"
+                            inputMode="tel"
                             className="h-12 text-lg"
-                            value={formData.contact ?? ''}
-                            onChange={(e) =>
-                                handleChange(
-                                    'contact',
-                                    e.target.value ? Number.parseInt(e.target.value, 10) : undefined
-                                )
-                            }
-                            placeholder="연락처를 입력하세요 (숫자만)…"
+                            value={contactInput}
+                            onChange={(e) => {
+                                setContactInput(e.target.value);
+                                setErrors((prev) => ({ ...prev, contact: '' }));
+                            }}
+                            placeholder="010-1234-1234"
                             disabled={isSubmitting}
                         />
                     </div>

--- a/packages/trpc/src/schemas/student.ts
+++ b/packages/trpc/src/schemas/student.ts
@@ -33,7 +33,7 @@ export const createStudentInputSchema = z.object({
     catholicName: z.string().optional(),
     gender: z.enum(['M', 'F']).optional(),
     age: z.number().int().positive().optional(),
-    contact: z.number().optional(),
+    contact: z.string().optional(),
     description: z.string().optional(),
     groupId: idSchema,
     baptizedAt: z
@@ -55,7 +55,7 @@ export const updateStudentInputSchema = z.object({
     catholicName: z.string().nullable().optional(),
     gender: z.enum(['M', 'F']).nullable().optional(),
     age: z.number().int().positive().nullable().optional(),
-    contact: z.number().nullable().optional(),
+    contact: z.string().nullable().optional(),
     description: z.string().nullable().optional(),
     groupId: idSchema.optional(),
     baptizedAt: z
@@ -162,7 +162,7 @@ export interface StudentBase {
     catholicName?: string;
     gender?: string;
     age?: number;
-    contact?: number;
+    contact?: string;
     description?: string;
     groupId: string;
     baptizedAt?: string;

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -2,13 +2,15 @@
  * 연락처를 포맷팅하여 반환 (010-XXXX-XXXX 형식)
  * 숫자로 저장되면서 앞의 0이 사라진 경우를 처리 (1012341234 → 010-1234-1234)
  *
- * @param contact 연락처 숫자 (e.g., 1012345678 또는 undefined)
+ * @param contact 연락처 문자열 (e.g., "1012345678" 또는 undefined)
  * @returns 포맷팅된 연락처 문자열
  */
-export const formatContact = (contact?: number | null): string => {
+export const formatContact = (contact?: string | null): string => {
     if (!contact) return '-';
+    const digits = contact.replace(/\D/g, '');
+    if (!digits) return '-';
     // 숫자로 저장되면서 앞의 0이 사라진 경우 (1012341234 → 01012341234)
-    const str = contact.toString().padStart(11, '0');
+    const str = digits.padStart(11, '0');
     return `${str.slice(0, 3)}-${str.slice(3, 7)}-${str.slice(7)}`;
 };
 

--- a/packages/utils/test/format.test.ts
+++ b/packages/utils/test/format.test.ts
@@ -6,16 +6,15 @@ import { describe, expect, it } from 'vitest';
 
 describe('format 유틸리티', () => {
     describe('formatContact', () => {
-        it('11자리 숫자를 010-XXXX-XXXX 형식으로 포맷한다', () => {
-            const result = formatContact(1012345678);
+        it('10자리 문자열을 010-XXXX-XXXX 형식으로 포맷한다', () => {
+            const result = formatContact('1012345678');
 
             // 앞에 0이 붙어서 01012345678이 됨
             expect(result).toBe('010-1234-5678');
         });
 
-        it('이미 11자리인 숫자를 올바르게 포맷한다', () => {
-            // 실제로는 BigInt 범위이지만, 일반 숫자로 처리 가능한 범위
-            const result = formatContact(1098765432);
+        it('이미 11자리인 문자열을 올바르게 포맷한다', () => {
+            const result = formatContact('1098765432');
 
             expect(result).toBe('010-9876-5432');
         });
@@ -32,15 +31,27 @@ describe('format 유틸리티', () => {
             expect(result).toBe('-');
         });
 
-        it('0을 입력하면 "-"를 반환한다', () => {
-            const result = formatContact(0);
+        it('빈 문자열을 입력하면 "-"를 반환한다', () => {
+            const result = formatContact('');
 
             expect(result).toBe('-');
         });
 
-        it('10자리 숫자를 11자리로 패딩하여 포맷한다', () => {
+        it('10자리 문자열을 11자리로 패딩하여 포맷한다', () => {
             // 10자리: 1012341234 → 01012341234
-            const result = formatContact(1012341234);
+            const result = formatContact('1012341234');
+
+            expect(result).toBe('010-1234-1234');
+        });
+
+        it('하이픈이 포함된 문자열을 올바르게 포맷한다', () => {
+            const result = formatContact('010-1234-1234');
+
+            expect(result).toBe('010-1234-1234');
+        });
+
+        it('공백이 포함된 문자열을 올바르게 포맷한다', () => {
+            const result = formatContact('010 1234 1234');
 
             expect(result).toBe('010-1234-1234');
         });


### PR DESCRIPTION
## Summary
연락처 필드를 number에서 string으로 변경하여 `010-1234-1234`, `010 1234 1234`, `01012341234` 등 다양한 입력 형식을 허용합니다. 제출 시 숫자만 자동으로 추출되어 저장됩니다.

## Changes
- **tRPC 스키마**: `contact: z.number()` → `z.string()`
- **프론트**: 입력필드를 `type="text"` + `inputMode="tel"`로 변경
- **포맷팅**: `formatContact()` 함수가 하이픈/공백 자동 제거 및 포맷팅
- **백엔드**: API 응답 시 숫자를 문자열로 반환 (`String(contact)`)
- **엑셀 Import**: `normalizedContact` 타입을 number → string으로 변경

## Test plan
- ✓ 타입 체크 통과 (API, Web, Utils)
- ✓ 전체 테스트 통과 (utils 131 + api 132)
- ✓ formatContact 테스트 확장 (하이픈, 공백 포함 형식)

🤖 Generated with [Claude Code](https://claude.com/claude-code)