### PR TITLE
fix: 엑셀 Import 전화번호 처리를 웹 폼과 통일

### DIFF
--- a/apps/web/src/features/student/components/StudentImportModal.tsx
+++ b/apps/web/src/features/student/components/StudentImportModal.tsx
@@ -6,6 +6,7 @@
 import type { ValidatedRow } from '../utils/excel-import';
 import { parseExcelFile, validateRows } from '../utils/excel-import';
 import { downloadExcelTemplate } from '../utils/excel-template';
+import { formatContact } from '@school/utils';
 import { Download, FileSpreadsheet, Loader2, Upload } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -291,7 +292,9 @@ export function StudentImportModal({ open, onOpenChange, groups, onImportSuccess
                                                       ? '여'
                                                       : row.gender || '-'}
                                             </TableCell>
-                                            <TableCell>{row.contact || '-'}</TableCell>
+                                            <TableCell>
+                                                {row.normalizedContact ? formatContact(row.normalizedContact) : '-'}
+                                            </TableCell>
                                             <TableCell>{row.baptizedAt || '-'}</TableCell>
                                             <TableCell>{row.age || '-'}</TableCell>
                                             <TableCell>{row.description || '-'}</TableCell>

--- a/apps/web/src/features/student/utils/excel-import.ts
+++ b/apps/web/src/features/student/utils/excel-import.ts
@@ -113,11 +113,11 @@ export const validateRows = (rows: ParsedRow[], groups: GroupInfo[]): ValidatedR
             }
         }
 
-        // 전화번호 숫자 추출
+        // 전화번호 숫자 추출 (Excel이 숫자로 처리하면서 앞자리 0이 사라지는 경우 복원)
         if (row.contact) {
             const digits = row.contact.replace(/\D/g, '');
             if (digits) {
-                normalizedContact = digits;
+                normalizedContact = digits.padStart(11, '0');
             } else {
                 errors.push('전화번호는 숫자만 입력해 주세요. 예: 01012345678');
             }


### PR DESCRIPTION
## Summary

엑셀 Import 시 전화번호 처리를 웹 폼과 동일하게 통일했습니다.

## Changes

- **전화번호 정규화**: Excel이 숫자로 처리하면서 앞자리 `0`이 사라지는 경우를 `padStart(11, '0')`로 복원하여 웹 폼과 동일한 11자리 형식으로 전송
- **미리보기 표시**: 엑셀 Import 모달의 미리보기 테이블에서 `formatContact()`로 `010-1234-1234` 형식으로 표시

## Test Results

- ✅ TypeCheck passed
- ✅ All tests passed (133 passed, 132 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)