### PR TITLE
fix: 사회적 증거 워딩을 계정 모델에 맞게 수정

### DIFF
--- a/apps/api/src/domains/account/application/count-accounts.usecase.ts
+++ b/apps/api/src/domains/account/application/count-accounts.usecase.ts
@@ -1,17 +1,25 @@
 /**
  * Count Accounts UseCase
  *
- * 전체 가입 계정 수 조회 (소프트 삭제 제외)
+ * 전체 가입 계정 수 + 성당 수 조회 (소프트 삭제 제외)
  */
 import type { GetAccountCountOutput } from '@school/trpc';
 import { database } from '~/infrastructure/database/database.js';
 
 export class CountAccountsUseCase {
     async execute(): Promise<GetAccountCountOutput> {
-        const count = await database.account.count({
-            where: { deletedAt: null },
-        });
+        const [accountCount, churchCount] = await Promise.all([
+            database.account.count({
+                where: { deletedAt: null },
+            }),
+            database.church.count({
+                where: {
+                    deletedAt: null,
+                    organizations: { some: { deletedAt: null } },
+                },
+            }),
+        ]);
 
-        return { count };
+        return { accountCount, churchCount };
     }
 }

--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -40,10 +40,12 @@ export function AuthLayout({ children }: AuthLayoutProps) {
                     }}
                 />
 
-                {countData && countData.count > 0 && (
+                {countData && countData.churchCount > 0 && (
                     <div className="flex items-center gap-3 text-lg text-muted-foreground xl:text-xl">
                         <Users className="h-6 w-6" />
-                        <span>{countData.count}개 단체가 이미 사용하고 있어요</span>
+                        <span>
+                            {countData.churchCount}개 본당에서 {countData.accountCount}개 계정을 사용중입니다
+                        </span>
                     </div>
                 )}
             </div>
@@ -53,10 +55,12 @@ export function AuthLayout({ children }: AuthLayoutProps) {
                 {/* 모바일 히어로 (compact) */}
                 <div className="mb-6 space-y-2 text-center lg:hidden">
                     <h1 className="text-2xl font-bold tracking-tight">매주 일요일, 이거 하나면 됩니다</h1>
-                    {countData && countData.count > 0 && (
+                    {countData && countData.churchCount > 0 && (
                         <div className="flex items-center justify-center gap-2 text-base text-muted-foreground">
                             <Users className="h-5 w-5" />
-                            <span>{countData.count}개 단체가 이미 사용하고 있어요</span>
+                            <span>
+                                {countData.churchCount}개 본당에서 {countData.accountCount}개 계정을 사용중입니다
+                            </span>
                         </div>
                     )}
                 </div>

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -191,10 +191,12 @@ export function LandingPage() {
                         id="cta"
                         className="flex min-h-screen flex-col items-center justify-center gap-10 bg-gradient-to-t from-primary/8 to-background px-6 text-center"
                     >
-                        {countData && countData.count > 0 && (
+                        {countData && countData.churchCount > 0 && (
                             <div className="flex flex-col items-center gap-2 text-lg font-medium text-balance sm:flex-row sm:gap-3 sm:text-2xl">
                                 <Users className="h-7 w-7 shrink-0 text-primary" />
-                                <span>{countData.count}개 단체가 이미 사용하고 있어요</span>
+                                <span>
+                                    {countData.churchCount}개 본당에서 {countData.accountCount}개 계정을 사용중입니다
+                                </span>
                             </div>
                         )}
                         <p className="text-lg text-muted-foreground sm:text-xl">

--- a/packages/trpc/src/schemas/account.ts
+++ b/packages/trpc/src/schemas/account.ts
@@ -65,7 +65,8 @@ export interface AgreePrivacyOutput {
  * 계정 수 조회 응답
  */
 export interface GetAccountCountOutput {
-    count: number;
+    accountCount: number;
+    churchCount: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- API 응답: 계정 수 + 본당 수 함께 반환 (churchCount 추가)
- 워딩: "N개 단체가 이미 사용하고 있어요" → "N개 본당에서 N개 계정을 사용중입니다"
- 3개 영역 (로그인/회원가입 데스크톱, 모바일, 랜딩 CTA) 동시 수정

## Test plan
✓ TypeCheck 통과
✓ 테스트 132개 전수 통과
✓ 계정 모델 전환 후 정확한 통계 데이터 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)