### PR TITLE
feat: GA4 커스텀 디멘션 추가 (계정명 + 단체명)

### DIFF
--- a/apps/web/src/features/auth/AuthProvider.tsx
+++ b/apps/web/src/features/auth/AuthProvider.tsx
@@ -97,6 +97,9 @@ export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
                 setOrganizationName(accountData.organizationName ?? null);
                 setOrganizationType(accountData.organizationType ?? null);
                 setChurchName(accountData.churchName ?? null);
+
+                // GA4 사용자 속성 설정
+                analytics.setUserProperties(accountData.displayName, accountData.organizationName ?? null);
             } else {
                 clearAuthState();
                 setAccount(null);
@@ -148,6 +151,9 @@ export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
         setOrganizationName(null);
         setOrganizationType(null);
         setChurchName(null);
+
+        // GA4 사용자 속성 초기화
+        analytics.clearUserProperties();
     }, [logoutMutation]);
 
     const value = useMemo(

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -25,6 +25,10 @@
  * - 온보딩 완료: analytics.trackOnboardingCompleted(daysSinceSignup)
  * - 전례 카드 노출: analytics.trackLiturgicalCardViewed()
  * - 축일자 카드 노출: analytics.trackPatronFeastCardViewed()
+ *
+ * 사용자 속성 (커스텀 디멘션):
+ * - 사용자 속성 설정: analytics.setUserProperties(accountName, organizationName)
+ * - 사용자 속성 초기화: analytics.clearUserProperties()
  */
 
 const isGtagAvailable = (): boolean => {
@@ -44,7 +48,42 @@ const safeGtag = (command: 'event', eventName: string, params?: Record<string, u
     }
 };
 
+const safeGtagSet = (targetId: string, params: Record<string, unknown>): void => {
+    if (!isGtagAvailable()) {
+        console.warn('[Analytics] gtag not available, skipping set:', targetId);
+        return;
+    }
+
+    try {
+        window.gtag!('set', targetId, params);
+    } catch (error) {
+        console.error('[Analytics] Failed to set:', targetId, error);
+    }
+};
+
 export const analytics = {
+    /**
+     * GA4 사용자 속성 설정 (커스텀 디멘션)
+     * 트리거: 계정 데이터 로드 완료 시 (AuthProvider)
+     * 설정 후 모든 이벤트에 자동 포함
+     */
+    setUserProperties: (accountName: string, organizationName: string | null): void => {
+        safeGtagSet('user_properties', {
+            account_name: accountName,
+            organization_name: organizationName ?? '',
+        });
+    },
+
+    /**
+     * GA4 사용자 속성 초기화
+     * 트리거: 로그아웃 시 (AuthProvider)
+     */
+    clearUserProperties: (): void => {
+        safeGtagSet('user_properties', {
+            account_name: '',
+            organization_name: '',
+        });
+    },
     /**
      * 회원가입 완료 이벤트
      * 트리거: 회원가입 API 성공 응답 수신 후

--- a/apps/web/src/types/gtag.d.ts
+++ b/apps/web/src/types/gtag.d.ts
@@ -6,7 +6,7 @@ interface GtagEventParams {
 }
 
 declare function gtag(
-    command: 'js' | 'config' | 'event',
+    command: 'js' | 'config' | 'event' | 'set',
     targetIdOrEventName: Date | string,
     params?: GtagEventParams | { [key: string]: unknown }
 ): void;

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 |---------------------------|------|---------------------------------------------------------------|
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 완료               |
 | **Target Functional**     | -    | 미착수 3건 (P1 미사 참례 + P2 가정 통신문 + P2 반편성) |
-| **Target Non-Functional** | -    | SECURITY 1건 완료, ANALYTICS 1건 미착수, PERFORMANCE 3건 미착수 |
+| **Target Non-Functional** | -    | SECURITY 1건 완료, ANALYTICS 1건 완료, PERFORMANCE 3건 미착수 |
 
 ## 관련 문서
 
@@ -99,12 +99,7 @@
 
 | 우선순위 | 기능명                  | SDD 상태 | 비고                                                   |
 |------|----------------------|--------|------------------------------------------------------|
-| P1   | GA4 account_id 커스텀 디멘션 | 미작성    | 클라이언트 GA4 이벤트에 account_id 추가 → 단체별 WAU 자동 측정 |
-
-**GA4 account_id 커스텀 디멘션:**
-- 현재 클라이언트(gtag.js) 19개 이벤트에 account_id 미포함 → GA4에서 단체별 분석 불가
-- 로그인 시 analytics 모듈에 accountId 세팅, 이후 모든 이벤트에 자동 포함
-- GA4 콘솔에서 커스텀 디멘션 등록 필요
+| P1   | GA4 커스텀 디멘션 (계정명+단체명) | **구현 완료** | account_name + organization_name user properties 추가 |
 
 ### PERFORMANCE (Non-Functional)
 


### PR DESCRIPTION
## Summary
- GA4 커스텀 디멘션 2개 추가: `account_name` (계정명), `organization_name` (단체명)
- 로그인 시 user properties 자동 세팅, 로그아웃 시 초기화
- 기존 29개 이벤트에 자동 포함 (개별 수정 불필요)

## 변경 파일
- `apps/web/src/lib/analytics.ts` — `setUserProperties()`, `clearUserProperties()` 추가
- `apps/web/src/features/auth/AuthProvider.tsx` — 계정 로드/로그아웃 시 호출
- `apps/web/src/types/gtag.d.ts` — `'set'` 커맨드 타입 추가
- `docs/specs/README.md` — ANALYTICS 상태 "구현 완료" 업데이트

## GA4 콘솔 수동 설정 필요
배포 후 GA4 콘솔에서 커스텀 디멘션 2개 등록:
1. 관리 > 커스텀 정의 > 커스텀 디멘션 만들기
2. `account_name` — 범위: 사용자
3. `organization_name` — 범위: 사용자

## Test plan
- [x] `pnpm lint:fix` 통과
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과
- [x] `pnpm test` 통과 (286 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)