### PR TITLE
fix: 출석 입력 시 groupId 누락 수정

### DIFF
--- a/apps/api/src/domains/attendance/application/update-attendance.usecase.ts
+++ b/apps/api/src/domains/attendance/application/update-attendance.usecase.ts
@@ -64,7 +64,7 @@ export class UpdateAttendanceUseCase {
 
             if (input.isFull) {
                 // 출석 입력 (insert or update)
-                row = await this.updateAttendance(input.year, input.attendance);
+                row = await this.updateAttendance(input.year, input.groupId, input.attendance);
             } else {
                 // 출석 삭제 (hard delete)
                 row = await this.deleteAttendance(input.year, input.attendance);
@@ -127,7 +127,7 @@ export class UpdateAttendanceUseCase {
     /**
      * 출석 데이터 업데이트 (insert or update)
      */
-    private async updateAttendance(year: number, attendance: AttendanceData[]): Promise<number> {
+    private async updateAttendance(year: number, groupId: string, attendance: AttendanceData[]): Promise<number> {
         return await database.$transaction(async (tx) => {
             let count = 0;
 
@@ -147,7 +147,7 @@ export class UpdateAttendanceUseCase {
                             date: fullTime,
                             content: item.data,
                             studentId: BigInt(item.id),
-                            groupId: null,
+                            groupId: BigInt(groupId),
                             createdAt: getNowKST(),
                         },
                     });

--- a/apps/api/test/integration/attendance.test.ts
+++ b/apps/api/test/integration/attendance.test.ts
@@ -133,6 +133,7 @@ describe('attendance 통합 테스트', () => {
             const caller = createScopedCaller(accountId, accountName, '1', '장위동 중고등부');
             const result = await caller.attendance.update({
                 year: 2024,
+                groupId: String(mockGroup.id),
                 attendance: [
                     {
                         id: String(mockStudent.id),
@@ -176,6 +177,7 @@ describe('attendance 통합 테스트', () => {
             const caller = createScopedCaller(accountId, accountName, '1', '장위동 중고등부');
             const result = await caller.attendance.update({
                 year: 2024,
+                groupId: String(mockGroup.id),
                 attendance: [
                     {
                         id: String(mockStudent.id),
@@ -197,6 +199,7 @@ describe('attendance 통합 테스트', () => {
             await expect(
                 caller.attendance.update({
                     year: 2024,
+                    groupId: '1',
                     attendance: [
                         {
                             id: '1',
@@ -222,6 +225,7 @@ describe('attendance 통합 테스트', () => {
             await expect(
                 caller.attendance.update({
                     year: 2024,
+                    groupId: '1',
                     attendance: [],
                     isFull: true,
                 })

--- a/apps/web/src/features/attendance/hooks/useAttendance.ts
+++ b/apps/web/src/features/attendance/hooks/useAttendance.ts
@@ -35,6 +35,7 @@ export function useAttendance(groupId: string, year?: number) {
         if (!year && !data?.year) return;
         return updateMutation.mutateAsync({
             year: year || data!.year,
+            groupId,
             attendance: attendanceData,
             isFull,
         });

--- a/apps/web/src/features/attendance/hooks/useCalendar.ts
+++ b/apps/web/src/features/attendance/hooks/useCalendar.ts
@@ -30,6 +30,7 @@ export function useCalendar(groupId: string, year: number, month: number) {
     const updateAttendance = async (attendanceData: AttendanceData[], isFull: boolean) => {
         return updateMutation.mutateAsync({
             year,
+            groupId,
             attendance: attendanceData,
             isFull,
         });

--- a/packages/shared/src/schemas/attendance.ts
+++ b/packages/shared/src/schemas/attendance.ts
@@ -19,6 +19,7 @@ const attendanceDataSchema = z.object({
  */
 export const updateAttendanceInputSchema = z.object({
     year: z.number().int().positive(),
+    groupId: idSchema,
     attendance: z.array(attendanceDataSchema).min(1, 'At least one attendance entry is required'),
     isFull: z.boolean(),
 });


### PR DESCRIPTION
## Summary

출석 생성 시 `groupId`가 `null`로 저장되던 버그를 수정했습니다.

- 스키마에 `groupId` 필드 추가
- 백엔드 UseCase에서 `groupId` 입력받아 DB에 저장
- 프론트엔드 훅에서 mutation 호출 시 `groupId` 전달
- 통합 테스트에 `groupId` 필드 추가

## Changes

- `packages/shared/src/schemas/attendance.ts`: `updateAttendanceInputSchema`에 `groupId` 필드 추가
- `apps/api/src/domains/attendance/application/update-attendance.usecase.ts`: groupId 파라미터 추가 및 DB 저장 로직 수정
- `apps/web/src/features/attendance/hooks/useCalendar.ts`, `useAttendance.ts`: mutation 호출 시 groupId 전달
- `apps/api/test/integration/attendance.test.ts`: 테스트에 groupId 추가

## Notes

기존 출석 레코드 중 groupId가 null인 경우는 별도 마이그레이션으로 처리 필요합니다.