### PR TITLE
fix: Docker 컨테이너 타임존 KST 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN pnpm turbo build --filter=@school/api
 # ===== Stage 2: Runner =====
 FROM node:24-alpine AS runner
 
+# 타임존 설정 (Alpine 기본값은 UTC → 스케줄러/로그를 KST로 맞춤)
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Seoul
+
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: ${DOCKERHUB_USERNAME:-username}/school-api:${TAG:-latest}
     container_name: school-api
     restart: unless-stopped
+    environment:
+      - TZ=Asia/Seoul
     env_file:
       - .env.production
     ports:


### PR DESCRIPTION
## Summary
Docker 컨테이너의 기본 타임존이 UTC였기 때문에 node-schedule 크론 작업과 로그 타임스탬프가 의도와 다르게 동작했습니다. Alpine 이미지에 tzdata를 설치하고 TZ=Asia/Seoul을 설정하여 해결했습니다.

## Changes
- **Dockerfile**: Runner stage에 tzdata 설치 및 TZ=Asia/Seoul 환경변수 설정
- **docker-compose.yml**: 런타임 환경에서 TZ=Asia/Seoul 명시

이제 스케줄러는 의도한 KST 시간(09:00, 21:00)에 동작하고 로그도 KST 타임스탬프로 기록됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)