### PR TITLE
fix: Kysely ORDER BY alias snake_case 변환

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -143,7 +143,7 @@ throw new TRPCError({
 - **타입**: `src/infrastructure/database/generated/types.ts` (prisma-kysely 자동 생성)
 - **DB**: MariaDB/MySQL
 
-복잡한 쿼리(JOIN, GROUP BY, HAVING, 집계)는 `database.$kysely` 사용. CamelCasePlugin으로 코드는 camelCase, `sql` 템플릿 내부만 DB snake_case 사용. `prisma generate` 시 Kysely 타입 자동 생성 (lint/prettier 제외).
+복잡한 쿼리(JOIN, GROUP BY, HAVING, 집계)는 `database.$kysely` 사용. CamelCasePlugin으로 코드는 camelCase, **`sql` 템플릿 내부는 반드시 DB snake_case** 사용. `.as('camelName')`도 SQL에서는 `snake_name`으로 변환되므로, ORDER BY 등에서 alias를 참조할 때 `sql`\`snake_name\``으로 작성해야 함. `prisma generate` 시 Kysely 타입 자동 생성 (lint/prettier 제외).
 
 ### KST 타임스탬프 정책
 

--- a/apps/api/src/domains/report/application/org-daily-report.usecase.ts
+++ b/apps/api/src/domains/report/application/org-daily-report.usecase.ts
@@ -37,9 +37,9 @@ export class OrgDailyReportUseCase {
             ])
             .where('o.deleteAt', 'is', null)
             .groupBy(['o.id', 'c.name', 'o.name', 'o.type'])
-            .orderBy(sql`recentAttendanceAt`, 'desc')
-            .orderBy(sql`recentStudentCreateAt`, 'desc')
-            .orderBy(sql`recentGroupCreateAt`, 'desc')
+            .orderBy(sql`recent_attendance_at`, 'desc')
+            .orderBy(sql`recent_student_create_at`, 'desc')
+            .orderBy(sql`recent_group_create_at`, 'desc')
             .$castTo<OrgActivityRow>()
             .execute();
     }


### PR DESCRIPTION
## 문제
9 PM 일일 보고서 스케줄러가 실행될 때 ORDER BY clause에서 'Unknown column' 에러 발생.

## 원인
CamelCasePlugin이 `.as('recentAttendanceAt')`를 SQL의 `recent_attendance_at`으로 변환하지만, `sql` 템플릿의 ORDER BY는 raw SQL이라 변환되지 않아 불일치 발생.

## 수정
ORDER BY의 sql 템플릿 내 alias를 snake_case로 수정:
- `recentAttendanceAt` → `recent_attendance_at`
- `recentStudentCreateAt` → `recent_student_create_at`
- `recentGroupCreateAt` → `recent_group_create_at`

## 규칙 추가
Kysely 사용 시 sql 템플릿 내 alias 참조 방식을 rules/api.md에 명시.