### PR TITLE
feat: 공개 페이지 SEO 개선

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,12 +11,40 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="주일학교 출석부 | 매주 일요일, 이거 하나면 됩니다" />
     <meta property="og:description" content="출석, 축일, 멤버 현황까지. 주일학교 교리교사를 위한 주간 도구. 지금 바로 시작하세요." />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:image" content="https://weekly-school.site/og-image.png" />
     <meta property="og:locale" content="ko_KR" />
 
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="canonical" href="https://weekly-school.site/landing" />
     <title>주일학교 출석부 | 매주 일요일, 이거 하나면 됩니다</title>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "주일학교 출석부",
+        "url": "https://weekly-school.site",
+        "applicationCategory": "EducationalApplication",
+        "operatingSystem": "Web",
+        "description": "출석, 축일, 멤버 현황까지. 주일학교 교리교사를 위한 주간 도구.",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "KRW"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "주일학교 출석부",
+        "url": "https://weekly-school.site",
+        "logo": "https://weekly-school.site/og-image.png"
+    }
+    </script>
 
     <!-- Google Analytics (GA4) -->
     <script>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
+        "@dr.pogodin/react-helmet": "^3.1.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/web/public/naver662984dfe222652105c820a39fa7ec67.html
+++ b/apps/web/public/naver662984dfe222652105c820a39fa7ec67.html
@@ -1,0 +1,1 @@
+naver-site-verification: naver662984dfe222652105c820a39fa7ec67.html

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -2,6 +2,7 @@ User-agent: *
 Allow: /landing
 Allow: /login
 Allow: /signup
+Allow: /donate
 Disallow: /api/
 Disallow: /join
 Disallow: /pending
@@ -13,3 +14,5 @@ Disallow: /attendance
 Disallow: /settings
 
 Sitemap: https://weekly-school.site/sitemap.xml
+
+#DaumWebMasterTool:9ed15fb346c803ab761c894e77ca0bbfae73e0e490c17214008227a679149f97:fQ6kuEgwzsAht48uP0ME1g==

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -2,16 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://weekly-school.site/landing</loc>
+    <lastmod>2026-03-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://weekly-school.site/login</loc>
+    <lastmod>2026-03-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://weekly-school.site/signup</loc>
+    <lastmod>2026-03-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://weekly-school.site/donate</loc>
+    <lastmod>2026-03-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -12,14 +13,16 @@ import '~/styles/globals.css';
 createRoot(document.getElementById('root')!).render(
     <GlobalErrorBoundary>
         <StrictMode>
-            <trpc.Provider client={trpcClient} queryClient={queryClient}>
-                <QueryClientProvider client={queryClient}>
-                    <AuthProvider>
-                        <App />
-                        <Toaster position="top-center" richColors closeButton duration={3000} />
-                    </AuthProvider>
-                </QueryClientProvider>
-            </trpc.Provider>
+            <HelmetProvider>
+                <trpc.Provider client={trpcClient} queryClient={queryClient}>
+                    <QueryClientProvider client={queryClient}>
+                        <AuthProvider>
+                            <App />
+                            <Toaster position="top-center" richColors closeButton duration={3000} />
+                        </AuthProvider>
+                    </QueryClientProvider>
+                </trpc.Provider>
+            </HelmetProvider>
         </StrictMode>
     </GlobalErrorBoundary>
 );

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { LoginForm } from './LoginForm';
+import { Helmet } from '@dr.pogodin/react-helmet';
 import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { AuthLayout } from '~/components/layout';
@@ -93,6 +94,11 @@ export function LoginPage() {
 
     return (
         <AuthLayout>
+            <Helmet>
+                <title>로그인 | 주일학교 출석부</title>
+                <meta name="description" content="주일학교 출석부에 로그인하세요." />
+                <link rel="canonical" href="https://weekly-school.site/login" />
+            </Helmet>
             <LoginForm onSubmit={handleSubmit} error={error} isLoading={isLoading} />
         </AuthLayout>
     );

--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from '@dr.pogodin/react-helmet';
 import { type FormEvent, useCallback, useEffect, useState } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { PrivacyPolicyDialog } from '~/components/common/PrivacyPolicyDialog';
@@ -130,6 +131,11 @@ export function SignupPage() {
 
     return (
         <AuthLayout>
+            <Helmet>
+                <title>회원가입 | 주일학교 출석부</title>
+                <meta name="description" content="지금 가입하고 주일학교 출석 관리를 시작하세요." />
+                <link rel="canonical" href="https://weekly-school.site/signup" />
+            </Helmet>
             <Card className="w-full max-w-md">
                 <CardHeader className="text-center">
                     <CardTitle className="text-2xl">회원가입</CardTitle>

--- a/apps/web/src/pages/donate/DonatePage.tsx
+++ b/apps/web/src/pages/donate/DonatePage.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from '@dr.pogodin/react-helmet';
 import { ArrowLeft, Heart } from 'lucide-react';
 import { useEffect } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
@@ -21,6 +22,11 @@ export function DonatePage() {
 
     return (
         <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
+            <Helmet>
+                <title>후원하기 | 주일학교 출석부</title>
+                <meta name="description" content="주일학교 출석부를 후원해주세요. 후원금은 서버 운영비로 사용됩니다." />
+                <link rel="canonical" href="https://weekly-school.site/donate" />
+            </Helmet>
             <div className="w-full max-w-md space-y-6">
                 <h1 className="text-center text-xl font-bold tracking-tight">주일학교 출석부</h1>
 

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { FadeInSection } from './FadeInSection';
 import { InteractiveDemo } from './InteractiveDemo';
 import { ScrollDownHint } from './ScrollDownHint';
+import { Helmet } from '@dr.pogodin/react-helmet';
 import { BarChart3, Calendar, ClipboardCheck, Users } from 'lucide-react';
 import { useEffect } from 'react';
 import { Link, Navigate, useNavigate } from 'react-router-dom';
@@ -105,8 +106,36 @@ export function LandingPage() {
         analytics.trackLandingLoginClick();
     };
 
+    const faqJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        'mainEntity': FAQ_ITEMS.map((item) => ({
+            '@type': 'Question',
+            'name': item.question,
+            'acceptedAnswer': {
+                '@type': 'Answer',
+                'text': item.answer,
+            },
+        })),
+    };
+
     return (
         <div className="min-h-screen bg-background">
+            <Helmet>
+                <title>주일학교 출석부 | 매주 일요일, 이거 하나면 됩니다</title>
+                <meta
+                    name="description"
+                    content="출석, 축일, 멤버 현황까지. 주일학교 교리교사를 위한 주간 도구. 지금 바로 시작하세요."
+                />
+                <link rel="canonical" href="https://weekly-school.site/landing" />
+                <meta property="og:title" content="주일학교 출석부 | 매주 일요일, 이거 하나면 됩니다" />
+                <meta
+                    property="og:description"
+                    content="출석, 축일, 멤버 현황까지. 주일학교 교리교사를 위한 주간 도구. 지금 바로 시작하세요."
+                />
+                <meta property="og:url" content="https://weekly-school.site/landing" />
+                <script type="application/ld+json">{JSON.stringify(faqJsonLd)}</script>
+            </Helmet>
             <main className="break-keep">
                 {/* ① Hero — 첫 화면은 즉시 표시 */}
                 <section className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-primary/8 to-background px-6 text-center">

--- a/apps/web/test/adsense-crawling.test.ts
+++ b/apps/web/test/adsense-crawling.test.ts
@@ -40,12 +40,13 @@ describe('sitemap.xml', () => {
         expect(content).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"');
     });
 
-    it('공개 페이지 3개의 URL을 포함한다', () => {
+    it('공개 페이지 4개의 URL을 포함한다', () => {
         const locMatches = content.match(/<loc>/g);
-        expect(locMatches).toHaveLength(3);
+        expect(locMatches).toHaveLength(4);
         expect(content).toContain('/landing</loc>');
         expect(content).toContain('/login</loc>');
         expect(content).toContain('/signup</loc>');
+        expect(content).toContain('/donate</loc>');
     });
 
     it('랜딩 페이지의 priority가 가장 높다', () => {

--- a/apps/web/test/donate-page.test.tsx
+++ b/apps/web/test/donate-page.test.tsx
@@ -3,6 +3,7 @@
  *
  * 공개 후원 페이지 렌더링, URL 미설정 시 리다이렉트 검증
  */
+import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -28,9 +29,11 @@ describe('DonatePage', () => {
 
         const { DonatePage } = await import('~/pages/donate/DonatePage');
         render(
-            <MemoryRouter>
-                <DonatePage />
-            </MemoryRouter>
+            <HelmetProvider>
+                <MemoryRouter>
+                    <DonatePage />
+                </MemoryRouter>
+            </HelmetProvider>
         );
 
         expect(screen.getByText('주일학교 출석부')).toBeInTheDocument();

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 |---------------------------|------|---------------------------------------------------------------|
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 없음 (도네이션 게스트 접근 구현 완료) |
-| **Target Non-Functional** | -    | PERFORMANCE 2건 미착수, 2건 완료 |
+| **Target Non-Functional** | -    | PERFORMANCE 2건 미착수, 2건 완료 + SEO 1건 완료 |
 
 ## 관련 문서
 
@@ -65,6 +65,19 @@
 | P2   | 졸업 처리 배치 쿼리 최적화       | ✅ 완료   | GraduateStudentsUseCase N+1 쿼리 → updateMany 리팩토링           |
 | P2   | 학생 목록 이중 쿼리 최적화       | 미착수    | StudentListPage 졸업 처리 시 active/graduated 두 훅이 각각 invalidate → 2회 API 호출 |
 | P2   | prisma-kysely 도입          | ✅ 완료   | raw query 6건 → Kysely 타입 세이프 쿼리 전환 |
+
+### SEO (Non-Functional)
+
+| 우선순위 | 기능명                       | SDD 상태 | 비고                                                       |
+|------|---------------------------|--------|---------------------------------------------------------|
+| P1   | 공개 페이지 SEO 개선            | ✅ 완료   | JSON-LD + 동적 Meta + Canonical + sitemap 갱신 + 검색엔진 인증 |
+
+**공개 페이지 SEO 개선:** ✅ 완료
+- JSON-LD 구조화 데이터 (FAQPage, Organization, WebApplication)
+- 페이지별 동적 meta tags (`@dr.pogodin/react-helmet`)
+- Canonical URL, sitemap에 /donate 추가, OG image 절대 경로
+- 네이버 서치어드바이저 + 다음 웹마스터 인증
+- 프리렌더링은 Puppeteer 의존성 부담으로 보류
 
 **웹 테스트 확대:**
 - 현재 API 통합 테스트 6개 + 유틸 테스트 4개만 존재

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dr.pogodin/react-helmet':
+        specifier: ^3.1.1
+        version: 3.1.1(react@19.2.3)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -611,6 +614,11 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dr.pogodin/react-helmet@3.1.1':
+    resolution: {integrity: sha512-+OvGxbL8s5DqG8Je2jPUnlKJJeRnqRAeLOzOoJctCj4EEKdjXmCrnJhRugT/Ma5skB77sItqqQcTaE5J6uGEaQ==}
+    peerDependencies:
+      react: '19'
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -4376,6 +4384,11 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dr.pogodin/react-helmet@3.1.1(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.3
 
   '@epic-web/invariant@1.0.0': {}
 


### PR DESCRIPTION
## Summary
- 공개 페이지(landing, login, signup, donate)에 페이지별 동적 meta tags 추가 (`@dr.pogodin/react-helmet`)
- JSON-LD 구조화 데이터 추가: FAQPage(랜딩), WebApplication, Organization (index.html)
- Canonical URL + OG image 절대 경로 변환
- sitemap.xml에 `/donate` 추가 + `lastmod` 필드
- robots.txt에 `/donate` Allow + 다음 웹마스터 인증 추가
- 네이버 서치어드바이저 HTML 인증 파일 추가

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 성공
- [x] `pnpm test` 전체 통과 (383 tests)
- [ ] 배포 후 네이버 서치어드바이저 인증 확인
- [ ] 배포 후 다음 웹마스터 인증 확인
- [ ] Google Search Console 등록 + sitemap 제출

🤖 Generated with [Claude Code](https://claude.com/claude-code)