### PR TITLE
perf: 통계 쿼리 DB 레벨 GROUP BY 전환 — 메모리 적재 제거

### DIFF
--- a/apps/api/src/domains/statistics/application/get-attendance-rate.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-attendance-rate.usecase.ts
@@ -3,7 +3,6 @@
  *
  * 주간/월간/연간 출석률 조회 (스냅샷 기반)
  */
-import { PRESENT_MARKS } from '@school/shared';
 import type { AttendanceRateOutput, StatisticsInput as StatisticsSchemaInput } from '@school/shared';
 import {
     clampToToday,
@@ -15,6 +14,7 @@ import {
     getWeekRangeInMonth,
     roundToDecimal,
 } from '@school/utils';
+import { PRESENT_COUNT_SQL } from '~/domains/statistics/statistics.helper.js';
 import { database } from '~/infrastructure/database/database.js';
 
 type StatisticsInput = StatisticsSchemaInput & { organizationId: string };
@@ -73,20 +73,7 @@ export class GetAttendanceRateUseCase {
             };
         }
 
-        // 4. 기간 내 출석 데이터 조회 (attendance.groupId 기반)
-        const allAttendances = await database.attendance.findMany({
-            where: {
-                deletedAt: null,
-                groupId: { in: groupIds },
-                date: {
-                    gte: startDateStr,
-                    lte: endDateStr,
-                },
-            },
-            select: { content: true },
-        });
-
-        // 5. 출석 일수 계산 (해당 기간 내 일요일 수)
+        // 4. 출석 일수 계산 (해당 기간 내 일요일 수)
         const totalDays = countSundays(startDate, endDate);
 
         if (totalDays === 0) {
@@ -101,14 +88,27 @@ export class GetAttendanceRateUseCase {
             };
         }
 
-        // 6. 실제 출석 수 (◎, ○, △)
-        const actualAttendances = allAttendances.filter((a) => a.content && PRESENT_MARKS.has(a.content)).length;
+        // 5. 기간 내 출석 인정(◎/○/△) 수 — DB 레벨 SUM(CASE) 단일 스칼라
+        const presentRow = await database.$kysely
+            .selectFrom('attendance as a')
+            .select(PRESENT_COUNT_SQL.as('presentCount'))
+            .where('a.deleteAt', 'is', null)
+            .where(
+                'a.groupId',
+                'in',
+                groupIds.map((id) => Number(id))
+            )
+            .where('a.date', '>=', startDateStr)
+            .where('a.date', '<=', endDateStr)
+            .executeTakeFirstOrThrow();
 
-        // 7. 출석률 계산
+        const actualAttendances = Number(presentRow.presentCount ?? 0);
+
+        // 6. 출석률 계산
         const expectedAttendances = totalStudents * totalDays;
         const attendanceRate = (actualAttendances / expectedAttendances) * 100;
 
-        // 8. 평균 출석 인원
+        // 7. 평균 출석 인원
         const avgAttendance = actualAttendances / totalDays;
 
         return {

--- a/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-by-gender.usecase.ts
@@ -3,7 +3,6 @@
  *
  * 성별 분포 조회 (스냅샷 기반)
  */
-import { PRESENT_MARKS } from '@school/shared';
 import type { GenderDistributionOutput, StatisticsInput as StatisticsSchemaInput } from '@school/shared';
 import {
     clampToToday,
@@ -15,6 +14,7 @@ import {
     roundToDecimal,
 } from '@school/utils';
 import { getBulkStudentSnapshots } from '~/domains/snapshot/snapshot.helper.js';
+import { PRESENT_COUNT_SQL } from '~/domains/statistics/statistics.helper.js';
 import { database } from '~/infrastructure/database/database.js';
 
 type StatisticsInput = StatisticsSchemaInput & { organizationId: string };
@@ -55,17 +55,7 @@ export class GetByGenderUseCase {
             return { year, male: { count: 0, rate: 0 }, female: { count: 0, rate: 0 }, unknown: { count: 0, rate: 0 } };
         }
 
-        // 4. 기간 내 출석 데이터 조회 (attendance.groupId 기반)
-        const allAttendances = await database.attendance.findMany({
-            where: {
-                deletedAt: null,
-                groupId: { in: groupIds },
-                date: { gte: startDateStr, lte: endDateStr },
-            },
-            select: { studentId: true, content: true },
-        });
-
-        // 5. 스냅샷에서 성별 정보 조회 (폴백: Student.gender)
+        // 4. 스냅샷에서 성별 정보 조회 (폴백: Student.gender)
         const referenceDate = new Date(year, 11, 31);
         const studentSnapshots = await getBulkStudentSnapshots(uniqueStudentIds, referenceDate);
 
@@ -80,40 +70,48 @@ export class GetByGenderUseCase {
             fallbackGenders = new Map(fallbackStudents.map((s) => [s.id, s.gender]));
         }
 
-        // 6. studentId → gender 매핑
-        const studentGenderMap = new Map<bigint, string | null>();
-        for (const studentId of uniqueStudentIds) {
-            const snapshot = studentSnapshots.get(studentId);
-            studentGenderMap.set(studentId, snapshot?.gender ?? fallbackGenders.get(studentId) ?? null);
-        }
-
-        // 7. 성별별 출석률 계산
+        // 5. 성별별 학생 ID 분류 (스냅샷 우선, 폴백 적용)
         const genderGroups = { M: new Set<bigint>(), F: new Set<bigint>(), unknown: new Set<bigint>() };
-        for (const [studentId, gender] of studentGenderMap) {
+        for (const studentId of uniqueStudentIds) {
+            const gender = studentSnapshots.get(studentId)?.gender ?? fallbackGenders.get(studentId) ?? null;
             if (gender === 'M') genderGroups.M.add(studentId);
             else if (gender === 'F') genderGroups.F.add(studentId);
             else genderGroups.unknown.add(studentId);
         }
 
-        const calcRate = (studentIds: Set<bigint>): { count: number; rate: number } => {
+        // 6. 성별별 출석률 계산 — 성별별 SUM(CASE) 1회씩, 병렬 실행
+        const groupIdsAsNumber = groupIds.map((id) => Number(id));
+        const calcRate = async (studentIds: Set<bigint>): Promise<{ count: number; rate: number }> => {
             const count = studentIds.size;
             if (count === 0 || totalDays === 0) return { count, rate: 0 };
 
-            const presentCount = allAttendances.filter(
-                (a) => studentIds.has(a.studentId) && a.content && PRESENT_MARKS.has(a.content)
-            ).length;
+            const presentRow = await database.$kysely
+                .selectFrom('attendance as a')
+                .select(PRESENT_COUNT_SQL.as('presentCount'))
+                .where('a.deleteAt', 'is', null)
+                .where('a.groupId', 'in', groupIdsAsNumber)
+                .where(
+                    'a.studentId',
+                    'in',
+                    [...studentIds].map((id) => Number(id))
+                )
+                .where('a.date', '>=', startDateStr)
+                .where('a.date', '<=', endDateStr)
+                .executeTakeFirstOrThrow();
 
+            const presentCount = Number(presentRow.presentCount ?? 0);
             const expected = count * totalDays;
             const rate = expected > 0 ? (presentCount / expected) * 100 : 0;
             return { count, rate: roundToDecimal(rate, 1) };
         };
 
-        return {
-            year,
-            male: calcRate(genderGroups.M),
-            female: calcRate(genderGroups.F),
-            unknown: calcRate(genderGroups.unknown),
-        };
+        const [male, female, unknown] = await Promise.all([
+            calcRate(genderGroups.M),
+            calcRate(genderGroups.F),
+            calcRate(genderGroups.unknown),
+        ]);
+
+        return { year, male, female, unknown };
     }
 
     /**

--- a/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-group-statistics.usecase.ts
@@ -3,7 +3,6 @@
  *
  * 모든 그룹의 주간/월간/연간 출석률 및 평균 출석 인원 조회 (스냅샷 기반)
  */
-import { PRESENT_MARKS } from '@school/shared';
 import type { GroupStatisticsOutput, StatisticsInput as StatisticsSchemaInput } from '@school/shared';
 import {
     clampToToday,
@@ -17,6 +16,7 @@ import {
     roundToDecimal,
 } from '@school/utils';
 import { getBulkGroupSnapshots } from '~/domains/snapshot/snapshot.helper.js';
+import { PRESENT_COUNT_SQL } from '~/domains/statistics/statistics.helper.js';
 import { database } from '~/infrastructure/database/database.js';
 
 type StatisticsInput = StatisticsSchemaInput & { organizationId: string };
@@ -155,33 +155,32 @@ export class GetGroupStatisticsUseCase {
     }
 
     /**
-     * 기간별 attendance 조회 + groupId별 그룹핑
+     * 기간별 출석 인정(◎/○/△) 수 조회 — DB 레벨 GROUP BY group_id
      */
     private async fetchPeriodData(groupIds: bigint[], range: DateRange): Promise<PeriodGroupData> {
         const startDateStr = formatDateCompact(range.startDate);
         const endDateStr = formatDateCompact(range.endDate);
         const totalDays = countSundays(range.startDate, range.endDate);
 
-        const attendances = await database.attendance.findMany({
-            where: {
-                deletedAt: null,
-                groupId: { in: groupIds },
-                date: { gte: startDateStr, lte: endDateStr },
-            },
-            select: { groupId: true, content: true },
-        });
+        const presentRows = await database.$kysely
+            .selectFrom('attendance as a')
+            .select('a.groupId')
+            .select(PRESENT_COUNT_SQL.as('presentCount'))
+            .where('a.deleteAt', 'is', null)
+            .where(
+                'a.groupId',
+                'in',
+                groupIds.map((id) => Number(id))
+            )
+            .where('a.date', '>=', startDateStr)
+            .where('a.date', '<=', endDateStr)
+            .groupBy('a.groupId')
+            .execute();
 
         const grouped = new Map<bigint, { presentCount: number }>();
-        for (const att of attendances) {
-            if (!att.groupId) continue;
-            let data = grouped.get(att.groupId);
-            if (!data) {
-                data = { presentCount: 0 };
-                grouped.set(att.groupId, data);
-            }
-            if (att.content && PRESENT_MARKS.has(att.content)) {
-                data.presentCount++;
-            }
+        for (const row of presentRows) {
+            if (row.groupId === null) continue;
+            grouped.set(BigInt(row.groupId), { presentCount: Number(row.presentCount ?? 0) });
         }
 
         return { grouped, totalDays, startDateStr, endDateStr };

--- a/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
+++ b/apps/api/src/domains/statistics/application/get-top-groups.usecase.ts
@@ -3,7 +3,6 @@
  *
  * 그룹별 출석률 순위 TOP N 조회 (스냅샷 기반)
  */
-import { PRESENT_MARKS } from '@school/shared';
 import type { TopGroupsOutput, TopStatisticsInput as TopStatisticsSchemaInput } from '@school/shared';
 import {
     clampToToday,
@@ -15,6 +14,7 @@ import {
     roundToDecimal,
 } from '@school/utils';
 import { getBulkGroupSnapshots } from '~/domains/snapshot/snapshot.helper.js';
+import { PRESENT_COUNT_SQL } from '~/domains/statistics/statistics.helper.js';
 import { database } from '~/infrastructure/database/database.js';
 
 type TopStatisticsInput = TopStatisticsSchemaInput & { organizationId: string };
@@ -62,23 +62,26 @@ export class GetTopGroupsUseCase {
             studentCountByGroup.set(sg.groupId, (studentCountByGroup.get(sg.groupId) ?? 0) + 1);
         }
 
-        // 4. 기간 내 출석 데이터 조회 (attendance.groupId 기반)
-        const attendances = await database.attendance.findMany({
-            where: {
-                deletedAt: null,
-                groupId: { in: groupIds },
-                date: { gte: startDateStr, lte: endDateStr },
-            },
-            select: { groupId: true, content: true },
-        });
+        // 4. 기간 내 출석 인정(◎/○/△) 수 — DB 레벨 GROUP BY group_id
+        const presentRows = await database.$kysely
+            .selectFrom('attendance as a')
+            .select('a.groupId')
+            .select(PRESENT_COUNT_SQL.as('presentCount'))
+            .where('a.deleteAt', 'is', null)
+            .where(
+                'a.groupId',
+                'in',
+                groupIds.map((id) => Number(id))
+            )
+            .where('a.date', '>=', startDateStr)
+            .where('a.date', '<=', endDateStr)
+            .groupBy('a.groupId')
+            .execute();
 
-        // 5. groupId별 출석 수 집계
         const presentByGroup = new Map<bigint, number>();
-        for (const att of attendances) {
-            if (!att.groupId) continue;
-            if (att.content && PRESENT_MARKS.has(att.content)) {
-                presentByGroup.set(att.groupId, (presentByGroup.get(att.groupId) ?? 0) + 1);
-            }
+        for (const row of presentRows) {
+            if (row.groupId === null) continue;
+            presentByGroup.set(BigInt(row.groupId), Number(row.presentCount ?? 0));
         }
 
         // 6. 그룹 이름 스냅샷 조회

--- a/apps/api/src/domains/statistics/statistics.helper.ts
+++ b/apps/api/src/domains/statistics/statistics.helper.ts
@@ -7,3 +7,9 @@ export const ATTENDANCE_SCORE_SQL = sql<number>`SUM(CASE
     WHEN a.content = '△' THEN 1
     ELSE 0
 END)`;
+
+/** 출석 인정(◎/○/△) 카운트 SQL */
+export const PRESENT_COUNT_SQL = sql<number>`SUM(CASE
+    WHEN a.content IN ('◎', '○', '△') THEN 1
+    ELSE 0
+END)`;

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
 | **Target Bugfix**         | -    | 12건 미착수 (P1 1건, P2 6건, P3 5건) + 5건 완료 |
-| **Target Non-Functional** | -    | PERFORMANCE 6건 미착수 + 1건 완료 + DX 2건 완료 |
+| **Target Non-Functional** | -    | PERFORMANCE 5건 미착수 + 2건 완료 + DX 2건 완료 |
 
 ## 관련 문서
 
@@ -65,7 +65,7 @@
 
 | 우선순위 | 기능명                       | SDD 상태 | 비고                                                       |
 |------|---------------------------|--------|---------------------------------------------------------|
-| P1   | 통계 쿼리 전체 메모리 로드          | 미착수    | 전체 출석 레코드 앱 메모리 적재 후 집계. DB 레벨 GROUP BY 집계로 전환 필요        |
+| P1   | 통계 쿼리 전체 메모리 로드          | ✅ 완료    | 4개 UseCase Kysely `GROUP BY` + `SUM(CASE)` 전환. `PRESENT_COUNT_SQL` 헬퍼 추가. 통합 테스트 20/20 통과 |
 | P2   | 웹 테스트 확대                 | 미작성    | 커버리지 ~2% → 주요 페이지/훅 테스트 추가                               |
 | P2   | Organization 목록 페이지네이션 미구현 | ✅ 완료 | skip/take 페이지네이션 + Pagination 컴포넌트 적용                       |
 | P2   | DB connectionLimit 환경별 분리 | 미착수    | connectionLimit: 10 하드코딩. 프로덕션 20-50 권장                    |

--- a/docs/specs/functional-design/statistics-aggregation-perf.md
+++ b/docs/specs/functional-design/statistics-aggregation-perf.md
@@ -1,0 +1,96 @@
+# 기능 설계: 통계 집계 DB 레벨 전환 (Performance)
+
+> 상태: Draft | 작성일: 2026-04-17 | 분류: Non-Functional (Performance, P1)
+
+## 연결 문서
+
+- 기능 설계 (SSoT): `docs/specs/functional-design/statistics.md`
+- TARGET 등록: `docs/specs/README.md` PERFORMANCE 표 P1
+
+## 배경
+
+통계 UseCase 4개가 `attendance.findMany()`로 전체 행을 Node 메모리에 적재한 뒤 JS `filter`/`forEach`로 집계한다. 데이터 증가 시 **메모리 사용량 + p95 응답 시간 동시 악화** 위험. 모델: `GetExcellentStudentsUseCase`/`GetTopOverallUseCase`는 이미 `database.$kysely` + `GROUP BY` 사용 중이며 패턴으로 정착.
+
+## 변경 대상 / 비대상
+
+| UseCase | 현재 | 전환 후 | 비고 |
+|---------|------|--------|------|
+| GetAttendanceRateUseCase | `findMany` + `filter().length` | Kysely `SUM(CASE)` 단일 스칼라 | 가장 단순 |
+| GetTopGroupsUseCase | `findMany` + `forEach Map` | Kysely `GROUP BY group_id` + `SUM(CASE)` | 정렬/limit는 JS 유지 |
+| GetGroupStatisticsUseCase | `findMany × 3` (주/월/년) + `forEach Map × 3` | Kysely `GROUP BY group_id` × 3 (Promise.all 유지) | 학년 그룹만 |
+| GetByGenderUseCase | `findMany` + `filter × 3` | Kysely `SUM(CASE)` 3회 (M/F/unknown) — `studentId IN` 절 사용 | 스냅샷 gender 결정 후 쿼리 |
+| GetExcellentStudentsUseCase | Kysely `GROUP BY` | 변경 없음 | 모델 패턴 |
+| GetTopOverallUseCase | Kysely `GROUP BY` | 변경 없음 | 모델 패턴 |
+
+## 동작 명세
+
+기능 동작은 **완전 동일**. 결과 dto/필드/필터링 규칙(졸업, 스냅샷 폴백, `PRESENT_MARKS = ◎/○/△`) 모두 보존. 변경은 집계 위치(JS → DB)뿐.
+
+### 알고리즘 (전환 후, 1줄 요약)
+
+- 출석 카운트: `SUM(CASE WHEN content IN ('◎','○','△') THEN 1 ELSE 0 END)`
+- 그룹별: `GROUP BY group_id` + 위 SUM
+- 성별: 스냅샷에서 결정한 (M/F/unknown 학생 ID 집합)을 `studentId IN (...)` 필터로 SUM 3회
+
+### 스냅샷/폴백 보존
+
+- `getBulkStudentSnapshots`, `getBulkGroupSnapshots`, missing → student/group 폴백 — 기존 로직 그대로. 집계 SQL 진입 **전에** 학생 ID 분류만 수행.
+
+### 공통 유틸 추가
+
+`statistics.helper.ts`에 출석 카운트 SQL 추가 (`ATTENDANCE_SCORE_SQL`와 동일 위치):
+
+```
+PRESENT_COUNT_SQL = SUM(CASE WHEN a.content IN ('◎','○','△') THEN 1 ELSE 0 END)
+```
+
+> 의사코드/완전한 SQL은 작성하지 않음. 코드(SSoT)와 `rules/api.md`(Kysely 규칙)에 위임.
+
+## 데이터/도메인 변경
+
+없음. 스키마/마이그레이션/Prisma 모델 변경 없음.
+
+## API/인터페이스
+
+8개 procedure 시그니처/응답 필드 변경 없음. tRPC 라우터·Zod 스키마 무변경.
+
+## 성능/제약
+
+| 항목 | 현재 | 목표 |
+|------|------|------|
+| 출석 행 메모리 적재 | 기간 내 모든 행 (수천~수만/조회) | **0행 적재** (스칼라/소수 행만 수신) |
+| 응답 시간 | findMany + JS 집계 (행 수 비례) | DB GROUP BY 단일 왕복 |
+| Kysely 사용 | 2개 UseCase | 6개 UseCase |
+| 인덱스 의존 | 없음 (앱 집계) | `attendance.(group_id, date)` 인덱스 권장 — BUGFIX P2 "Attendance 인덱스 누락"과 시너지 (이번 범위 외) |
+
+## 예외/엣지 케이스
+
+| 상황 | 처리 (변화 없음) |
+|------|---------------|
+| groupIds 빈 배열 | 출석 쿼리 생략, 0/빈 결과 즉시 반환 |
+| totalDays 0 | 출석률 0% 즉시 반환 |
+| 스냅샷 없음 | 현재 엔티티 폴백 (Student/Group) |
+| `att.groupId` null | DB GROUP BY가 자연 제외. JS `if (!groupId) continue` 로직 제거 |
+
+## 테스트 시나리오
+
+### 정상 케이스 (회귀)
+
+- **TC-1**: 기존 `apps/api/test/integration/statistics.test.ts` 521줄 전체 통과 — 결과 dto 동일성이 회귀 게이트.
+- **TC-2**: 졸업생 필터링 케이스 (test:408-464) 통과 유지.
+- **TC-3**: 성별 분포 케이스 (test:494-518) 통과 유지.
+
+### 예외 케이스
+
+- **TC-E1**: 빈 organization (그룹 0개) → 모든 procedure 0/빈 결과.
+- **TC-E2**: `groupId IS NULL` 출석 행 존재 시 — 그룹 통계에서 자연 제외 확인 (DB GROUP BY 동작).
+- **TC-E3**: PRESENT_MARKS 외 content (예: `'×'`, null) → 카운트 0 확인.
+
+## 자기 검증 체크리스트
+
+- [x] 동작 명세 수준 (구현 상세 위임)
+- [x] PRD 요구사항 = "DB 레벨 GROUP BY 집계로 전환" 반영
+- [x] 결과 동일성 (스냅샷/폴백/졸업 필터 전부 보존) 명시
+- [x] 변경 대상/비대상 표로 명확화
+- [x] 비기능 워크플로우(Task/Dev 생략) 고려해 짧게 유지 (190줄 이내)
+- [x] 기존 `statistics.md` SSoT는 무변경 (기능 동작 변화 없음)


### PR DESCRIPTION
## Summary

- 통계 4개 UseCase가 `attendance.findMany`로 전체 행을 Node 메모리에 적재 후 JS `filter`/`forEach`로 집계하던 패턴을 Kysely `GROUP BY` + `SUM(CASE)`로 전환 (`docs/specs/README.md` PERFORMANCE P1).
- `statistics.helper.ts`에 `PRESENT_COUNT_SQL` 헬퍼 추가 — 기존 `ATTENDANCE_SCORE_SQL` 옆에 동일 패턴.
- 모델 패턴은 이미 Kysely + GROUP BY를 사용하던 `GetExcellentStudentsUseCase` / `GetTopOverallUseCase`.

## 변경 대상 (4개 UseCase)

| UseCase | 전환 전 → 전환 후 |
|---------|------------------|
| `GetAttendanceRateUseCase` | `findMany + filter().length` → `SUM(CASE)` 스칼라 |
| `GetTopGroupsUseCase` | `findMany + forEach Map` → `GROUP BY group_id` |
| `GetGroupStatisticsUseCase` | `fetchPeriodData × 3 + forEach Map × 3` → `GROUP BY group_id × 3` (Promise.all 유지) |
| `GetByGenderUseCase` | `findMany + filter × 3` → `SUM(CASE) × 3` (Promise.all 병렬, `studentId IN`) |

## 동작 동일성

- API 응답 dto / 필드 / 라우터 시그니처 변경 없음
- 스냅샷 우선 + Student/Group 폴백 로직 보존
- 졸업 필터 (`graduatedAt >= 기간_시작일`) 보존
- `PRESENT_MARKS = ◎/○/△` 인정 규칙 보존
- 스키마/마이그레이션 변경 없음

## 기능 설계

`docs/specs/functional-design/statistics-aggregation-perf.md` (비기능 워크플로우, Task/Development 생략).

## Test plan

- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과
- [x] `pnpm test` 통과 (16 files, 211 tests)
- [x] `apps/api/test/integration/statistics.test.ts` 회귀 게이트 통과 (20/20)
- [ ] 프로덕션 모니터링 — 통계 procedure p95 응답 시간 / 메모리 사용량 변화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)