### PR TITLE
chore: DB connectionLimit 환경변수화 (Prisma v7 default 유지)

### DIFF
--- a/apps/api/src/global/config/env.ts
+++ b/apps/api/src/global/config/env.ts
@@ -1,7 +1,7 @@
 import pkg from '../../../package.json' with { type: 'json' };
 import dotenv from 'dotenv';
 import { join } from 'node:path';
-import { getOsEnv, getOsEnvOptional, normalizePort } from '~/global/utils/index.js';
+import { getOsEnv, getOsEnvIntOptional, getOsEnvOptional, normalizePort } from '~/global/utils/index.js';
 
 /**
  * Load .env file or for tests the .env.test file.
@@ -32,6 +32,7 @@ export const env = {
         username: getOsEnv('MYSQL_USERNAME'),
         password: getOsEnv('MYSQL_PASSWORD'),
         schema: getOsEnv('MYSQL_SCHEMA'),
+        connectionLimit: getOsEnvIntOptional('MYSQL_CONNECTION_LIMIT', 10, 1, 100),
     },
     app: {
         name: getOsEnv('APP_NAME'),

--- a/apps/api/src/global/utils/utils.ts
+++ b/apps/api/src/global/utils/utils.ts
@@ -13,6 +13,19 @@ export const getOsEnvOptional = (key: string, defaultValue = ''): string => {
     return process.env[key] ?? defaultValue;
 };
 
+export const getOsEnvIntOptional = (key: string, defaultValue: number, min: number, max: number): number => {
+    const raw = process.env[key];
+    if (raw === undefined || raw === '') return defaultValue;
+
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed) || parsed < min || parsed > max) {
+        const message = `Environment variable ${key} must be an integer in [${min}, ${max}]. got: ${raw}`;
+        logger.error(message);
+        throw new Error(message);
+    }
+    return parsed;
+};
+
 export const normalizePort = (port: string): number | string | boolean => {
     const parsedPort = Number.parseInt(port, 10);
     if (Number.isNaN(parsedPort)) {

--- a/apps/api/src/infrastructure/database/database.ts
+++ b/apps/api/src/infrastructure/database/database.ts
@@ -38,7 +38,7 @@ const adapter = new PrismaMariaDb({
     user: env.mysql.username,
     password: env.mysql.password,
     database: env.mysql.schema,
-    connectionLimit: 10,
+    connectionLimit: env.mysql.connectionLimit,
 });
 
 // PrismaClient 생성 (adapter 주입)

--- a/apps/api/test/unit/utils/get-os-env-int-optional.test.ts
+++ b/apps/api/test/unit/utils/get-os-env-int-optional.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOsEnvIntOptional } from '~/global/utils/utils.js';
+
+const KEY = '__TEST_INT_ENV__';
+
+describe('getOsEnvIntOptional', () => {
+    beforeEach(() => {
+        delete process.env[KEY];
+    });
+
+    afterEach(() => {
+        delete process.env[KEY];
+    });
+
+    it('미설정 시 default 반환', () => {
+        expect(getOsEnvIntOptional(KEY, 10, 1, 100)).toBe(10);
+    });
+
+    it('빈 문자열도 default 반환', () => {
+        process.env[KEY] = '';
+        expect(getOsEnvIntOptional(KEY, 10, 1, 100)).toBe(10);
+    });
+
+    it('정상 정수 문자열은 그대로 반환', () => {
+        process.env[KEY] = '30';
+        expect(getOsEnvIntOptional(KEY, 10, 1, 100)).toBe(30);
+    });
+
+    it('범위 경계값 (min/max) 허용', () => {
+        process.env[KEY] = '1';
+        expect(getOsEnvIntOptional(KEY, 10, 1, 100)).toBe(1);
+        process.env[KEY] = '100';
+        expect(getOsEnvIntOptional(KEY, 10, 1, 100)).toBe(100);
+    });
+
+    it('비정수 문자열은 throw', () => {
+        process.env[KEY] = 'abc';
+        expect(() => getOsEnvIntOptional(KEY, 10, 1, 100)).toThrow(/must be an integer/);
+    });
+
+    it('범위 미만은 throw', () => {
+        process.env[KEY] = '0';
+        expect(() => getOsEnvIntOptional(KEY, 10, 1, 100)).toThrow(/must be an integer in \[1, 100\]/);
+    });
+
+    it('범위 초과는 throw', () => {
+        process.env[KEY] = '200';
+        expect(() => getOsEnvIntOptional(KEY, 10, 1, 100)).toThrow(/must be an integer in \[1, 100\]/);
+    });
+
+    it('음수는 throw', () => {
+        process.env[KEY] = '-5';
+        expect(() => getOsEnvIntOptional(KEY, 10, 1, 100)).toThrow(/must be an integer/);
+    });
+});

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
 | **Target Bugfix**         | -    | 12건 미착수 (P1 1건, P2 6건, P3 5건) + 5건 완료 |
-| **Target Non-Functional** | -    | PERFORMANCE 5건 미착수 + 2건 완료 + DX 2건 완료 |
+| **Target Non-Functional** | -    | PERFORMANCE 4건 미착수 + 3건 완료 + DX 2건 완료 |
 
 ## 관련 문서
 
@@ -68,7 +68,7 @@
 | P1   | 통계 쿼리 전체 메모리 로드          | ✅ 완료    | 4개 UseCase Kysely `GROUP BY` + `SUM(CASE)` 전환. `PRESENT_COUNT_SQL` 헬퍼 추가. 통합 테스트 20/20 통과 |
 | P2   | 웹 테스트 확대                 | 미작성    | 커버리지 ~2% → 주요 페이지/훅 테스트 추가                               |
 | P2   | Organization 목록 페이지네이션 미구현 | ✅ 완료 | skip/take 페이지네이션 + Pagination 컴포넌트 적용                       |
-| P2   | DB connectionLimit 환경별 분리 | 미착수    | connectionLimit: 10 하드코딩. 프로덕션 20-50 권장                    |
+| P2   | DB connectionLimit 환경변수화 | ✅ 완료    | `MYSQL_CONNECTION_LIMIT` 추가(선택, default 10 — Prisma v7 표준). 검증 1~100. 단위 테스트 8/8 통과 |
 | P3   | 프로덕션 쿼리 로깅 비활성화          | 미착수    | 전체 쿼리 이벤트 로깅 상시 활성. PII 노출 위험 + 성능 오버헤드                   |
 | P3   | 트랜잭션/쿼리 타임아웃 미설정         | 미착수    | 장기 실행 트랜잭션 락 점유 가능. 명시적 타임아웃 설정 필요                         |
 | P3   | AuthLayout 이미지 dimensions 누락 | 미착수    | width/height 미설정 → CLS(레이아웃 시프트) 유발. loading="lazy" 추가 권장 |

--- a/docs/specs/functional-design/db-connection-limit.md
+++ b/docs/specs/functional-design/db-connection-limit.md
@@ -1,0 +1,109 @@
+# 기능 설계: DB connectionLimit 환경변수화 (Configurability)
+
+> 상태: Draft | 작성일: 2026-04-17 | 분류: Non-Functional (Performance, P2)
+
+## 연결 문서
+
+- 코드: `apps/api/src/infrastructure/database/database.ts:41`
+- 환경설정: `apps/api/src/global/config/env.ts`
+- TARGET 등록: `docs/specs/README.md` PERFORMANCE 표 P2
+- 참조: [Prisma Docs — Connection Pool](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#mysql-or-mariadb-using-the-mariadb-driver)
+
+## 배경
+
+`PrismaMariaDb` 어댑터의 `connectionLimit: 10`이 코드에 하드코딩되어 있다. 이 값 자체는 **Prisma v7 공식 default와 일치**(v7부터 모든 드라이버 어댑터가 10으로 통일)이므로 잘못된 값은 아니다. 다만 코드 수정 없이는 환경별 조정·운영 튜닝이 불가능한 **구성 부채**이다.
+
+이번 작업의 목표는 성능 개선이 아니라 **구성 가능성 확보**이다. Default는 Prisma v7 기준 그대로 두고, 필요 시 환경변수로 override 가능하게 한다.
+
+## 목표 / 비목표
+
+| 구분 | 항목 |
+|------|------|
+| **목표** | (1) 매직 넘버 제거 → env 참조. (2) 테스트 환경에서 작은 값 적용 가능. (3) 운영 비상 튜닝 시 재배포 없이 환경변수만으로 조정 가능. |
+| **비목표** | 성능 개선·풀 고갈 해결. (필요성은 옵션 C 모니터링으로 별도 확인) |
+
+## 변경 대상 / 비대상
+
+| 대상 | 현재 | 전환 후 |
+|------|------|--------|
+| `database.ts` connection pool 크기 | `10` 하드코딩 | `env.mysql.connectionLimit` 참조 |
+| `env.ts` mysql 섹션 | `connectionLimit` 없음 | `connectionLimit: number` 추가 (선택, default 10) |
+| `.env.example`, `.env.test.example` | 키 없음 | `MYSQL_CONNECTION_LIMIT` 안내 추가 |
+| 운영 환경(.env.local/.env.test/.env) | 미설정 | 미설정 유지 → default 10 적용 (현재 동작 보존) |
+
+> Prisma 자체 connection pool, 트랜잭션 타임아웃, 쿼리 타임아웃 등은 변경 없음 (별도 P3 항목).
+
+## 동작 명세
+
+### 환경변수 계약
+
+| 키 | 타입 | 필수 | 기본값 | 검증 |
+|---|------|----|------|------|
+| `MYSQL_CONNECTION_LIMIT` | 정수 문자열 | **선택** | `10` (Prisma v7 기준) | 설정 시 `1 ≤ n ≤ 100` |
+
+- **미설정**: default 10 적용 (현재 동작과 100% 동일).
+- **설정 + 정상**: 해당 값 적용.
+- **설정 + 비정상** (NaN, 범위 외): 부팅 시 throw (Fail-fast로 잘못된 운영 설정 차단).
+
+### 적용 위치
+
+`database.ts`의 `PrismaMariaDb({ ..., connectionLimit })`만 `env.mysql.connectionLimit`로 교체. 기존 슬로우 쿼리 로깅·Kysely 확장·`connectDatabase()` 모두 무변경.
+
+### `.env.example` 안내 주석
+
+```
+# DB 커넥션 풀 크기 (선택, default 10 — Prisma v7 표준)
+# MYSQL_CONNECTION_LIMIT=10
+```
+
+테스트 환경(`.env.test.example`)에는 `5` 권장 주석.
+
+## 데이터/도메인 변경
+
+없음.
+
+## API/인터페이스
+
+없음.
+
+## 성능/제약
+
+| 항목 | 현재 | 목표 |
+|------|------|------|
+| connection pool default | 10 (하드코딩) | 10 (env 참조) — **동작 동일** |
+| 운영 튜닝 | 코드 수정+재배포 필요 | 환경변수만 변경 |
+| 테스트 풀 크기 | 10 (불필요하게 큼) | 5 권장 (오버헤드 감소) |
+
+> 이번 PR로 **프로덕션 동작은 변하지 않음**. 풀 크기 변경은 운영자가 모니터링 후 별도 결정.
+
+## 예외/엣지 케이스
+
+| 상황 | 처리 |
+|------|------|
+| `MYSQL_CONNECTION_LIMIT` 미설정 | default 10 → 부팅 정상 (회귀 없음) |
+| 비정수 값 (`"abc"`) | parseInt → NaN 검증 → throw |
+| 범위 외 (`0`, `-1`, `200`) | 검증 실패 → throw (운영 실수 차단) |
+| 풀 고갈 런타임 | adapter 자체 에러 (이번 범위 외) |
+
+## 테스트 시나리오
+
+### 정상 케이스
+
+- **TC-1**: `MYSQL_CONNECTION_LIMIT` 미설정 시 default 10 적용 — 기존 통합 테스트 전체 통과 (회귀 게이트).
+- **TC-2**: env 파싱 단위 테스트 — 정상 정수 문자열이 `number`로 변환됨.
+- **TC-3**: env 미설정 시 default 10 반환 단위 테스트.
+
+### 예외 케이스
+
+- **TC-E1**: `MYSQL_CONNECTION_LIMIT=abc` 시 부팅 throw.
+- **TC-E2**: `MYSQL_CONNECTION_LIMIT=0` 또는 `=200` 시 부팅 throw.
+
+## 자기 검증 체크리스트
+
+- [x] 동작 명세 수준 (구현 상세 위임)
+- [x] **목표를 "성능 개선"이 아닌 "구성 가능성 확보"로 명시** — Prisma v7 default 일치 사실 반영
+- [x] Default 10 유지 → 현재 동작 보존, 회귀 위험 0
+- [x] 환경변수는 **선택**(default 있음) — Fail-fast는 "설정했는데 잘못된 값"일 때만
+- [x] 변경 대상/비대상 표로 명확화
+- [x] 비기능 워크플로우(Task/Dev 생략) 고려해 짧게 유지 (190줄 이내)
+- [x] 회귀 게이트(통합 테스트 전체 통과) 명시


### PR DESCRIPTION
## Summary

- `apps/api/src/infrastructure/database/database.ts`의 하드코딩된 `connectionLimit: 10`을 환경변수 기반으로 전환
- `MYSQL_CONNECTION_LIMIT` 환경변수 추가 (선택, default `10` — Prisma v7 표준과 일치)
- `getOsEnvIntOptional(key, default, min, max)` 범용 헬퍼 신설 + 단위 테스트 8건

## 배경

[Prisma v7 docs](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#mysql-or-mariadb-using-the-mariadb-driver) 기준 MariaDB driver의 `connectionLimit` default는 `10`. 즉 현재 값 자체는 잘못되지 않았으나 코드 수정 없이는 환경별 조정이 불가능한 **구성 부채**였음.

이번 PR의 목표는 **성능 개선이 아닌 구성 가능성 확보**:
1. 매직 넘버 제거 → env 참조
2. 테스트 환경 작은 풀 크기(`5`) 적용 가능
3. 운영 비상 튜닝 시 재배포 없이 환경변수만으로 조정

**Default 10 유지로 프로덕션 동작은 무변경 (회귀 위험 0).**

## 변경 사항

| 파일 | 변경 |
|------|------|
| `apps/api/src/global/utils/utils.ts` | `getOsEnvIntOptional(key, default, min, max)` 추가 — 미설정/빈값은 default, 비정수/범위 외는 throw |
| `apps/api/src/global/config/env.ts` | `mysql.connectionLimit: getOsEnvIntOptional('MYSQL_CONNECTION_LIMIT', 10, 1, 100)` |
| `apps/api/src/infrastructure/database/database.ts` | 하드코딩 → `env.mysql.connectionLimit` 참조 |
| `apps/api/test/unit/utils/get-os-env-int-optional.test.ts` | 신규 단위 테스트 8건 |
| `docs/specs/functional-design/db-connection-limit.md` | 기능 설계 문서 신규 |
| `docs/specs/README.md` | TARGET 항목 → ✅ 완료 |

## 동작 명세

| 키 | 필수 | 기본값 | 검증 |
|---|----|------|------|
| `MYSQL_CONNECTION_LIMIT` | 선택 | `10` | `1 ≤ n ≤ 100` |

- **미설정**: default 10 (현재 동작과 100% 동일)
- **설정 + 정상**: 해당 값 적용
- **설정 + 비정상**: 부팅 시 throw (Fail-fast)

## ⚠️ 별도 작업 필요 (권한 차단)

`apps/api/.env.example`, `apps/api/.env.test.example`은 PreToolUse hook 보호로 자동 수정 불가. 다음 항목을 수동으로 추가 필요:

```bash
# DB 커넥션 풀 크기 (선택, default 10 — Prisma v7 표준. 1~100 범위)
# MYSQL_CONNECTION_LIMIT=10
```

`.env.test.example`에는 권장값 `5` 안내 주석 권장.

## Test plan

- [x] `pnpm lint:fix && pnpm prettier:fix` — 통과 (FULL TURBO cached)
- [x] `pnpm typecheck` — 통과 (FULL TURBO cached)
- [x] `pnpm build` — 통과 (5/5 packages)
- [x] `pnpm test` — **219/219** 통과 (신규 단위 테스트 8건 포함)
- [x] 단위 테스트 케이스: 미설정/빈문자열/정상값/경계값(1, 100)/비정수/범위외(0, 200)/음수
- [ ] 운영 배포 후 DB connection metric 모니터링 → 풀 크기 상향 필요 시 환경변수만 조정

🤖 Generated with [Claude Code](https://claude.com/claude-code)