### PR TITLE
perf: DB 쿼리 로깅 환경변수 제어 + PII 마스킹

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -161,6 +161,10 @@ await database.student.create({
 
 `pnpm prisma generate` (클라이언트+Kysely 타입 생성), `pnpm prisma db push`, `pnpm prisma studio`
 
+### DB 환경변수
+
+`MYSQL_CONNECTION_LIMIT` (1~100, default 10), `DB_QUERY_LOGGING` (off/slow/all, default slow, 슬로우 쿼리 PII 마스킹). 상세: `.env.example`
+
 ## Testing
 
 - **프레임워크**: Vitest

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,8 @@ MYSQL_PORT=3306
 MYSQL_USERNAME=change_me
 MYSQL_PASSWORD=change_me
 MYSQL_SCHEMA=change_me
+# 커넥션 풀 크기 (선택, default 10, 범위 1~100)
+MYSQL_CONNECTION_LIMIT=10
 
 #
 # PRISMA

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,3 +37,7 @@ GA4_API_SECRET=change_me
 SMTP_USER=your-email@gmail.com
 SMTP_PASS=xxxx-xxxx-xxxx-xxxx
 ADMIN_EMAIL=admin@example.com
+
+# DB 쿼리 로깅 - off | slow | all (default: slow)
+# off: query 이벤트 비활성 (슬로우 쿼리 감지 X). slow: 슬로우 쿼리(>=1000ms)만. all: 모든 쿼리 (local 개발용)
+DB_QUERY_LOGGING=slow

--- a/apps/api/.env.test.example
+++ b/apps/api/.env.test.example
@@ -8,6 +8,8 @@ MYSQL_PORT=3307
 MYSQL_USERNAME=test
 MYSQL_PASSWORD=test
 MYSQL_SCHEMA=school_test
+# 테스트 커넥션 풀 (선택, default 10, 범위 1~100)
+MYSQL_CONNECTION_LIMIT=5
 
 # App
 APP_NAME=test

--- a/apps/api/.env.test.example
+++ b/apps/api/.env.test.example
@@ -17,3 +17,6 @@ APP_PORT=3000
 JWT_SECRET=test-secret-key-for-integration-tests
 JWT_EXPIRE_ACCESS=1h
 JWT_EXPIRE_REFRESH=7d
+
+# 테스트 환경: off로 운영 → query 이벤트 자체 비활성화
+DB_QUERY_LOGGING=off

--- a/apps/api/src/global/config/env.ts
+++ b/apps/api/src/global/config/env.ts
@@ -1,7 +1,16 @@
 import pkg from '../../../package.json' with { type: 'json' };
 import dotenv from 'dotenv';
 import { join } from 'node:path';
-import { getOsEnv, getOsEnvIntOptional, getOsEnvOptional, normalizePort } from '~/global/utils/index.js';
+import {
+    getOsEnv,
+    getOsEnvEnumOptional,
+    getOsEnvIntOptional,
+    getOsEnvOptional,
+    normalizePort,
+} from '~/global/utils/index.js';
+
+export const DB_QUERY_LOGGING_MODES = ['off', 'slow', 'all'] as const;
+export type DbQueryLoggingMode = (typeof DB_QUERY_LOGGING_MODES)[number];
 
 /**
  * Load .env file or for tests the .env.test file.
@@ -33,6 +42,9 @@ export const env = {
         password: getOsEnv('MYSQL_PASSWORD'),
         schema: getOsEnv('MYSQL_SCHEMA'),
         connectionLimit: getOsEnvIntOptional('MYSQL_CONNECTION_LIMIT', 10, 1, 100),
+    },
+    db: {
+        queryLogging: getOsEnvEnumOptional<DbQueryLoggingMode>('DB_QUERY_LOGGING', DB_QUERY_LOGGING_MODES, 'slow'),
     },
     app: {
         name: getOsEnv('APP_NAME'),

--- a/apps/api/src/global/utils/utils.ts
+++ b/apps/api/src/global/utils/utils.ts
@@ -26,6 +26,18 @@ export const getOsEnvIntOptional = (key: string, defaultValue: number, min: numb
     return parsed;
 };
 
+export const getOsEnvEnumOptional = <T extends string>(key: string, allowed: readonly T[], defaultValue: T): T => {
+    const raw = process.env[key];
+    if (raw === undefined || raw === '') return defaultValue;
+
+    if (!allowed.includes(raw as T)) {
+        const message = `Environment variable ${key} must be one of [${allowed.join(', ')}]. got: ${raw}`;
+        logger.error(message);
+        throw new Error(message);
+    }
+    return raw as T;
+};
+
 export const normalizePort = (port: string): number | string | boolean => {
     const parsedPort = Number.parseInt(port, 10);
     if (Number.isNaN(parsedPort)) {

--- a/apps/api/src/infrastructure/database/database.ts
+++ b/apps/api/src/infrastructure/database/database.ts
@@ -1,5 +1,6 @@
 import { PrismaMariaDb } from '@prisma/adapter-mariadb';
 import { PrismaClient } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import type { ITXClientDenyList } from '@prisma/client/runtime/library';
 import { Kysely, MysqlAdapter, MysqlIntrospector, MysqlQueryCompiler } from 'kysely';
 import kyselyExtension from 'prisma-extension-kysely';
@@ -11,23 +12,29 @@ import { logger } from '~/infrastructure/logger/logger.js';
 // 슬로우 쿼리 임계값 (ms)
 const SLOW_QUERY_THRESHOLD = 1000;
 
+const MASKED = "'***'";
+
 /**
- * SQL 쿼리의 ? 플레이스홀더를 실제 파라미터 값으로 치환
+ * 파라미터 JSON 배열의 각 값을 SQL 리터럴로 마스킹/직렬화.
+ * 문자열/Date/기타 타입 = 마스킹('***'), 숫자/bigint/null = 원값 유지.
  */
-const interpolateQuery = (query: string, params: string): string => {
+const maskParam = (value: unknown): string => {
+    if (value === null) return 'NULL';
+    if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+    return MASKED;
+};
+
+/**
+ * SQL 쿼리의 ? 플레이스홀더를 마스킹된 파라미터 값으로 치환.
+ * PII(이메일, 이름, 비밀번호 해시 등) 노출을 방지한다.
+ */
+export const interpolateQuery = (query: string, params: string): string => {
     try {
         const parsedParams: unknown[] = JSON.parse(params);
         let index = 0;
-        return query.replaceAll('?', () => {
-            const value = parsedParams[index++];
-            if (value === null) return 'NULL';
-            if (typeof value === 'string') return `'${value}'`;
-            if (typeof value === 'number' || typeof value === 'bigint') return String(value);
-            if (value instanceof Date) return `'${value.toISOString()}'`;
-            return String(value);
-        });
+        return query.replaceAll('?', () => maskParam(parsedParams[index++]));
     } catch {
-        return `${query} -- params: ${params}`;
+        return `${query} -- params: <masked>`;
     }
 };
 
@@ -41,30 +48,38 @@ const adapter = new PrismaMariaDb({
     connectionLimit: env.mysql.connectionLimit,
 });
 
-// PrismaClient 생성 (adapter 주입)
-const baseClient = new PrismaClient({
-    adapter,
-    log: [
-        { emit: 'event', level: 'query' },
+// 쿼리 로깅 모드에 따른 log 배열 구성.
+// 'off': query 이벤트 비발행 → 핸들러 등록 자체 생략 → 오버헤드 제거.
+const buildLogConfig = (): Prisma.LogDefinition[] => {
+    const base: Prisma.LogDefinition[] = [
         { emit: 'stdout', level: 'error' },
         { emit: 'stdout', level: 'warn' },
-    ],
+    ];
+    if (env.db.queryLogging === 'off') return base;
+    return [{ emit: 'event', level: 'query' }, ...base];
+};
+
+const baseClient = new PrismaClient({
+    adapter,
+    log: buildLogConfig(),
 });
 
-// Query 이벤트 핸들러 등록 ($on은 $extends 전에 호출해야 함)
-baseClient.$on('query', (event) => {
-    const duration = event.duration;
-    const query = event.query;
-    const params = event.params;
-    const interpolated = interpolateQuery(query, params);
+// Query 이벤트 핸들러는 'slow'/'all' 모드에서만 등록 ($on은 $extends 전에 호출해야 함)
+if (env.db.queryLogging !== 'off') {
+    baseClient.$on('query', (event) => {
+        const { duration, query, params } = event;
+        const isSlow = duration >= SLOW_QUERY_THRESHOLD;
 
-    // 슬로우 쿼리 감지
-    if (duration >= SLOW_QUERY_THRESHOLD) {
-        logger.err(`[SLOW QUERY] ${duration}ms - ${interpolated}`);
-    } else if (env.mode.local) {
-        logger.sql(`${duration}ms - ${interpolated}`);
-    }
-});
+        if (isSlow) {
+            logger.err(`[SLOW QUERY] ${duration}ms - ${interpolateQuery(query, params)}`);
+            return;
+        }
+
+        if (env.db.queryLogging === 'all') {
+            logger.sql(`${duration}ms - ${interpolateQuery(query, params)}`);
+        }
+    });
+}
 
 // $transaction 콜백의 tx 타입 (확장 포함)
 export type TransactionClient = Omit<typeof database, ITXClientDenyList>;

--- a/apps/api/test/unit/database/interpolate-query.test.ts
+++ b/apps/api/test/unit/database/interpolate-query.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { interpolateQuery } from '~/infrastructure/database/database.js';
+
+describe('interpolateQuery (PII 마스킹)', () => {
+    it('문자열 파라미터는 *** 로 마스킹', () => {
+        const result = interpolateQuery(
+            'SELECT * FROM account WHERE email = ? AND name = ?',
+            JSON.stringify(['user@example.com', '홍길동'])
+        );
+        expect(result).toBe("SELECT * FROM account WHERE email = '***' AND name = '***'");
+    });
+
+    it('숫자 및 bigint 파라미터는 원값 유지', () => {
+        const result = interpolateQuery(
+            'SELECT * FROM student WHERE id = ? AND organization_id = ?',
+            JSON.stringify([42, 100])
+        );
+        expect(result).toBe('SELECT * FROM student WHERE id = 42 AND organization_id = 100');
+    });
+
+    it('null 파라미터는 NULL 키워드로 치환', () => {
+        const result = interpolateQuery('SELECT * FROM student WHERE deleted_at = ?', JSON.stringify([null]));
+        expect(result).toBe('SELECT * FROM student WHERE deleted_at = NULL');
+    });
+
+    it('Date(ISO 문자열)는 *** 로 마스킹 (생일 등 PII 보호)', () => {
+        // JSON.stringify는 Date를 ISO 문자열로 직렬화 → 문자열 규칙 적용
+        const result = interpolateQuery(
+            'SELECT * FROM student WHERE birth_date = ?',
+            JSON.stringify([new Date('2010-05-15T00:00:00.000Z')])
+        );
+        expect(result).toBe("SELECT * FROM student WHERE birth_date = '***'");
+    });
+
+    it('숫자와 문자열 혼합 - 숫자만 노출', () => {
+        const result = interpolateQuery(
+            'UPDATE account SET password = ? WHERE id = ?',
+            JSON.stringify(['hashed_secret_xyz', 7])
+        );
+        expect(result).toBe("UPDATE account SET password = '***' WHERE id = 7");
+    });
+
+    it('객체/배열은 *** 로 마스킹', () => {
+        const result = interpolateQuery('INSERT INTO log (payload) VALUES (?)', JSON.stringify([{ foo: 'bar' }]));
+        expect(result).toBe("INSERT INTO log (payload) VALUES ('***')");
+    });
+
+    it('빈 파라미터 배열 - 원본 쿼리 그대로', () => {
+        const result = interpolateQuery('SELECT 1', JSON.stringify([]));
+        expect(result).toBe('SELECT 1');
+    });
+
+    it('JSON 파싱 실패 시 원본 params 미노출', () => {
+        const result = interpolateQuery('SELECT * FROM account WHERE email = ?', 'not-valid-json');
+        expect(result).toBe('SELECT * FROM account WHERE email = ? -- params: <masked>');
+        expect(result).not.toContain('not-valid-json');
+    });
+});

--- a/apps/api/test/unit/utils/get-os-env-enum-optional.test.ts
+++ b/apps/api/test/unit/utils/get-os-env-enum-optional.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOsEnvEnumOptional } from '~/global/utils/utils.js';
+
+const KEY = '__TEST_ENUM_ENV__';
+const ALLOWED = ['off', 'slow', 'all'] as const;
+
+describe('getOsEnvEnumOptional', () => {
+    beforeEach(() => {
+        delete process.env[KEY];
+    });
+
+    afterEach(() => {
+        delete process.env[KEY];
+    });
+
+    it('미설정 시 default 반환', () => {
+        expect(getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toBe('slow');
+    });
+
+    it('빈 문자열도 default 반환', () => {
+        process.env[KEY] = '';
+        expect(getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toBe('slow');
+    });
+
+    it('허용된 값은 그대로 반환', () => {
+        process.env[KEY] = 'off';
+        expect(getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toBe('off');
+        process.env[KEY] = 'all';
+        expect(getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toBe('all');
+    });
+
+    it('허용되지 않은 값은 throw', () => {
+        process.env[KEY] = 'verbose';
+        expect(() => getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toThrow(/must be one of \[off, slow, all\]/);
+    });
+
+    it('대소문자 구분하여 엄격 매칭', () => {
+        process.env[KEY] = 'OFF';
+        expect(() => getOsEnvEnumOptional(KEY, ALLOWED, 'slow')).toThrow(/must be one of/);
+    });
+});

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
 | **Target Bugfix**         | -    | 12건 미착수 (P1 1건, P2 6건, P3 5건) + 5건 완료 |
-| **Target Non-Functional** | -    | PERFORMANCE 4건 미착수 + 3건 완료 + DX 2건 완료 |
+| **Target Non-Functional** | -    | PERFORMANCE 3건 미착수 + 4건 완료 + DX 2건 완료 |
 
 ## 관련 문서
 
@@ -69,7 +69,7 @@
 | P2   | 웹 테스트 확대                 | 미작성    | 커버리지 ~2% → 주요 페이지/훅 테스트 추가                               |
 | P2   | Organization 목록 페이지네이션 미구현 | ✅ 완료 | skip/take 페이지네이션 + Pagination 컴포넌트 적용                       |
 | P2   | DB connectionLimit 환경변수화 | ✅ 완료    | `MYSQL_CONNECTION_LIMIT` 추가(선택, default 10 — Prisma v7 표준). 검증 1~100. 단위 테스트 8/8 통과 |
-| P3   | 프로덕션 쿼리 로깅 비활성화          | 미착수    | 전체 쿼리 이벤트 로깅 상시 활성. PII 노출 위험 + 성능 오버헤드                   |
+| P3   | 프로덕션 쿼리 로깅 비활성화          | ✅ 완료    | `DB_QUERY_LOGGING` 환경변수(off/slow/all) + 슬로우 쿼리 PII 마스킹. 단위 테스트 13/13 통과 |
 | P3   | 트랜잭션/쿼리 타임아웃 미설정         | 미착수    | 장기 실행 트랜잭션 락 점유 가능. 명시적 타임아웃 설정 필요                         |
 | P3   | AuthLayout 이미지 dimensions 누락 | 미착수    | width/height 미설정 → CLS(레이아웃 시프트) 유발. loading="lazy" 추가 권장 |
 | P3   | name 컬럼 인덱스 누락 (parish/church/organization) | 미착수 | `WHERE name = ?` 풀 스캔. 데이터 소규모이나 증가 시 성능 저하 |


### PR DESCRIPTION
## Summary

- **성능**: `DB_QUERY_LOGGING=off` 선택 시 Prisma `query` 이벤트 자체 비발행 → 매 쿼리마다 발생하던 `interpolateQuery` 오버헤드 제거. default는 `slow` (슬로우 쿼리 감지 유지)
- **보안(PII)**: 슬로우 쿼리 로그의 문자열/Date/객체 파라미터를 `'***'`로 마스킹. 숫자/bigint/null만 원값 유지 → 이메일·이름·비밀번호 해시 등 PII 로그 유출 차단
- **문서화**: `MYSQL_CONNECTION_LIMIT` 환경변수 예시를 `.env.example`·`.env.test.example`에 뒤늦게 추가 (#245 에서 코드만 추가되었음)

## 변경

### 커밋 1 — `perf: DB 쿼리 로깅 환경변수 제어`
- `DB_QUERY_LOGGING` 환경변수 (`off` \| `slow` \| `all`, default `slow`)
- `off`: `query` 이벤트 미발행, `$on` 미등록 → 슬로우 감지 X
- `slow`: 슬로우 쿼리(≥1000ms)만 로깅
- `all`: 모든 쿼리 로깅 (로컬 개발용)
- 슬로우 쿼리 로그 파라미터 PII 마스킹
- `getOsEnvEnumOptional<T>` 헬퍼 추가
- 단위 테스트 13건 (마스킹 8 + enum 5)

### 커밋 2 — `docs: MYSQL_CONNECTION_LIMIT 예시 추가`
- `.env.example`: `MYSQL_CONNECTION_LIMIT=10`
- `.env.test.example`: `MYSQL_CONNECTION_LIMIT=5`

## SDD 문서
- `docs/specs/target/non-functional/db-query-logging.md` 삭제 (비기능 완료 → 코드가 SSoT)
- `docs/specs/README.md` PERFORMANCE 테이블 상태 갱신: 3건 미착수 + 4건 완료
- `.claude/rules/api.md` DB 환경변수 섹션 추가 (1줄 인라인)

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과
- [x] `pnpm test` 통과 — **232/232** (신규 13건 포함)
- [ ] 스테이징에서 `DB_QUERY_LOGGING=off` 구동 후 쿼리 이벤트 미발생 확인
- [ ] 스테이징에서 슬로우 쿼리 발생 시 로그에 파라미터 값이 `'***'`로 마스킹됨 확인

## 알려진 참고 사항

- `숫자/bigint는 원값 유지`: ID·페이지·count 등 디버깅 가치 > PII 리스크로 판단. 설계 문서 기반 정책 (`docs/specs/target/non-functional/db-query-logging.md`는 완료 후 삭제됨)
- `.claude/rules/api.md` 는 원본부터 190줄 초과 상태였으며, 이번 PR은 +4줄 최소 추가 (202줄). 별도 리팩터링 작업 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)