### PR TITLE
fix: ApproveJoin TOCTOU — 트랜잭션 내 조건부 업데이트로 동시 승인 race 방어

### DIFF
--- a/apps/api/src/domains/organization/application/approve-join.usecase.ts
+++ b/apps/api/src/domains/organization/application/approve-join.usecase.ts
@@ -18,28 +18,39 @@ export class ApproveJoinUseCase {
             });
         }
 
-        const joinRequest = await database.joinRequest.findFirst({
-            where: {
-                id: BigInt(input.joinRequestId),
-                organizationId: BigInt(organizationId),
-                status: JOIN_REQUEST_STATUS.PENDING,
-            },
-        });
-
-        if (!joinRequest) {
-            throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: 'NOT_FOUND: 합류 요청을 찾을 수 없습니다',
-            });
-        }
-
         const now = getNowKST();
 
         await database.$transaction(async (tx) => {
-            await tx.joinRequest.update({
-                where: { id: joinRequest.id },
+            const joinRequest = await tx.joinRequest.findFirst({
+                where: {
+                    id: BigInt(input.joinRequestId),
+                    organizationId: BigInt(organizationId),
+                },
+            });
+
+            if (!joinRequest) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'NOT_FOUND: 합류 요청을 찾을 수 없습니다',
+                });
+            }
+
+            // 조건부 업데이트: PENDING 상태에서만 성공.
+            // 동시 승인 시 먼저 커밋된 트랜잭션만 count=1, 이후 요청은 count=0으로 race 감지
+            const approved = await tx.joinRequest.updateMany({
+                where: {
+                    id: joinRequest.id,
+                    status: JOIN_REQUEST_STATUS.PENDING,
+                },
                 data: { status: JOIN_REQUEST_STATUS.APPROVED, updatedAt: now },
             });
+
+            if (approved.count === 0) {
+                throw new TRPCError({
+                    code: 'CONFLICT',
+                    message: 'CONFLICT: 이미 처리된 합류 요청입니다',
+                });
+            }
 
             const account = await tx.account.update({
                 where: { id: joinRequest.accountId },

--- a/apps/api/test/integration/approve-join.test.ts
+++ b/apps/api/test/integration/approve-join.test.ts
@@ -1,0 +1,166 @@
+/**
+ * ApproveJoin 통합 테스트 (실제 DB)
+ *
+ * 합류 요청 승인 플로우 + TOCTOU 레이스 컨디션 방어 검증
+ */
+import { type SeedBase, seedBase, truncateAll } from '../helpers/db-lifecycle.ts';
+import { createScopedCaller } from '../helpers/trpc-caller.ts';
+import { JOIN_REQUEST_STATUS, ROLE } from '@school/shared';
+import { getNowKST } from '@school/utils';
+import bcrypt from 'bcrypt';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { database } from '~/infrastructure/database/database.js';
+
+let seed: SeedBase;
+
+const createApplicantAndRequest = async () => {
+    const now = getNowKST();
+    const applicant = await database.account.create({
+        data: {
+            name: '신청자',
+            displayName: '신청자',
+            password: bcrypt.hashSync('5678', 10),
+            role: null,
+            organizationId: null,
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const joinRequest = await database.joinRequest.create({
+        data: {
+            accountId: applicant.id,
+            organizationId: seed.org.id,
+            status: JOIN_REQUEST_STATUS.PENDING,
+            createdAt: now,
+            updatedAt: now,
+        },
+    });
+    return { applicant, joinRequest };
+};
+
+beforeEach(async () => {
+    await truncateAll();
+    seed = await seedBase();
+});
+
+afterAll(async () => {
+    await truncateAll();
+});
+
+describe('organization.approveJoin 통합 테스트', () => {
+    it('TC-1: ADMIN이 PENDING 요청 승인 → APPROVED + 계정 조직 할당 + 스냅샷 생성', async () => {
+        const { applicant, joinRequest } = await createApplicantAndRequest();
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name);
+
+        await caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) });
+
+        const updatedRequest = await database.joinRequest.findUnique({ where: { id: joinRequest.id } });
+        expect(updatedRequest?.status).toBe(JOIN_REQUEST_STATUS.APPROVED);
+
+        const updatedAccount = await database.account.findUnique({ where: { id: applicant.id } });
+        expect(updatedAccount?.organizationId).toBe(seed.org.id);
+        expect(updatedAccount?.role).toBe(ROLE.TEACHER);
+
+        const snapshots = await database.accountSnapshot.findMany({ where: { accountId: applicant.id } });
+        expect(snapshots).toHaveLength(1);
+    });
+
+    it('TC-2: non-admin(TEACHER) 요청 → FORBIDDEN', async () => {
+        const { joinRequest } = await createApplicantAndRequest();
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name, {
+            role: ROLE.TEACHER,
+        });
+
+        await expect(caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) })).rejects.toMatchObject({
+            code: 'FORBIDDEN',
+        });
+    });
+
+    it('TC-3: 존재하지 않는 joinRequestId → NOT_FOUND', async () => {
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name);
+
+        await expect(caller.organization.approveJoin({ joinRequestId: '999999' })).rejects.toMatchObject({
+            code: 'NOT_FOUND',
+        });
+    });
+
+    it('TC-4: 다른 organization의 joinRequest → NOT_FOUND', async () => {
+        const { joinRequest } = await createApplicantAndRequest();
+        const otherOrg = await database.organization.create({
+            data: { name: '다른조직', type: 'ELEMENTARY', churchId: seed.church.id, createdAt: getNowKST() },
+        });
+        const otherAdmin = await database.account.create({
+            data: {
+                name: '다른관리자',
+                displayName: '다른관리자',
+                password: bcrypt.hashSync('5678', 10),
+                role: ROLE.ADMIN,
+                organizationId: otherOrg.id,
+                createdAt: getNowKST(),
+                privacyAgreedAt: getNowKST(),
+            },
+        });
+        const caller = createScopedCaller(String(otherAdmin.id), otherAdmin.name, String(otherOrg.id), otherOrg.name);
+
+        await expect(caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) })).rejects.toMatchObject({
+            code: 'NOT_FOUND',
+        });
+    });
+
+    it('TC-5: 이미 APPROVED된 요청 재승인 → CONFLICT', async () => {
+        const { joinRequest } = await createApplicantAndRequest();
+        await database.joinRequest.update({
+            where: { id: joinRequest.id },
+            data: { status: JOIN_REQUEST_STATUS.APPROVED, updatedAt: getNowKST() },
+        });
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name);
+
+        await expect(caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) })).rejects.toMatchObject({
+            code: 'CONFLICT',
+        });
+    });
+
+    it('TC-6: 이미 REJECTED된 요청 승인 → CONFLICT', async () => {
+        const { joinRequest } = await createApplicantAndRequest();
+        await database.joinRequest.update({
+            where: { id: joinRequest.id },
+            data: { status: JOIN_REQUEST_STATUS.REJECTED, updatedAt: getNowKST() },
+        });
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name);
+
+        await expect(caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) })).rejects.toMatchObject({
+            code: 'CONFLICT',
+        });
+    });
+
+    // 핵심 TOCTOU 방어 케이스
+    it('TC-E1: 동시 승인 시 정확히 1건만 성공, 나머지는 CONFLICT — account/snapshot 중복 없음', async () => {
+        const { applicant, joinRequest } = await createApplicantAndRequest();
+        const caller = createScopedCaller(seed.ids.accountId, seed.account.name, seed.ids.orgId, seed.org.name);
+
+        // 5개의 동시 승인 요청 발사 (InnoDB 행 잠금으로 직렬화되나 결과는 1개만 성공해야 함)
+        const results = await Promise.allSettled(
+            Array.from({ length: 5 }, () => caller.organization.approveJoin({ joinRequestId: String(joinRequest.id) }))
+        );
+
+        const fulfilled = results.filter((r) => r.status === 'fulfilled');
+        const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+
+        expect(fulfilled).toHaveLength(1);
+        expect(rejected).toHaveLength(4);
+        for (const r of rejected) {
+            expect(r.reason).toMatchObject({ code: 'CONFLICT' });
+        }
+
+        const updatedRequest = await database.joinRequest.findUnique({ where: { id: joinRequest.id } });
+        expect(updatedRequest?.status).toBe(JOIN_REQUEST_STATUS.APPROVED);
+
+        const updatedAccount = await database.account.findUnique({ where: { id: applicant.id } });
+        expect(updatedAccount?.organizationId).toBe(seed.org.id);
+        expect(updatedAccount?.role).toBe(ROLE.TEACHER);
+
+        // 스냅샷은 성공한 트랜잭션에서 단 1번만 생성되어야 함
+        const snapshots = await database.accountSnapshot.findMany({ where: { accountId: applicant.id } });
+        expect(snapshots).toHaveLength(1);
+    });
+});

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 |---------------------------|------|---------------------------------------------------------------|
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
-| **Target Bugfix**         | -    | 11건 미착수 (P1 1건, P2 5건, P3 5건) + 6건 완료 |
+| **Target Bugfix**         | -    | 10건 미착수 (P1 1건, P2 4건, P3 5건) + 7건 완료 |
 | **Target Non-Functional** | -    | PERFORMANCE 3건 미착수 + 4건 완료 + DX 2건 완료 |
 
 ## 관련 문서
@@ -82,7 +82,7 @@
 | P1 | TRPCError 삼킴 — catch 블록 패턴 누락 | ✅ 완료 | 7개 UseCase catch 블록에 `if (e instanceof TRPCError) throw e` 패턴 추가 완료 |
 | P1 | RefreshToken createdAt UTC/KST 불일치 | ✅ 완료 | 5개 파일 8개 지점 `new Date()` → `getNowKST()` 통일 완료 |
 | P2 | 마이그레이션 SQL 비멱등성 | 미착수 | `cleanup_orphan_account_groups.sql` hardcoded ID 기반. 재실행 시 주의 필요. 1회성 정리이므로 수용 가능 |
-| P2 | ApproveJoinUseCase TOCTOU 레이스 컨디션 | 미착수 | PENDING 확인이 트랜잭션 밖. 동시 승인 시 중복 처리 가능 |
+| P2 | ApproveJoinUseCase TOCTOU 레이스 컨디션 | ✅ 완료 | `updateMany(status=PENDING)` 조건부 업데이트로 트랜잭션 내 원자성 확보. 동시 승인 시 1건만 성공, 후속 요청 CONFLICT. 통합 테스트 7/7 통과 (TC-E1 5-way race 포함) |
 | P2 | Attendance 테이블 인덱스 누락 | 미착수 | studentId, date 인덱스 없음. 데이터 증가 시 성능 저하 |
 | P3 | Attendance 중복 레코드 방지 | 미착수 | (studentId, date) 유니크 제약 부재. 트랜잭션 내이므로 위험도 낮음 |
 | P1 | Account.name DB 유니크 제약 미비 | 미착수 | 앱 레벨 체크만 존재. 동시 가입 시 race condition으로 중복 계정 생성 가능 |


### PR DESCRIPTION
## Summary
- **버그**: `ApproveJoinUseCase`의 `PENDING` 상태 확인이 트랜잭션 밖에 있어, admin 2명이 동일 합류 요청을 동시에 승인하면 양쪽 다 사전 검증을 통과한 뒤 `account.update` + `createAccountSnapshot`이 중복 실행될 수 있었음
- **수정**: `findFirst`의 status 필터 제거 + `updateMany({ where: { id, status: PENDING } })` 조건부 업데이트로 변경. InnoDB 행 잠금이 두 트랜잭션을 직렬화하고, 먼저 커밋된 트랜잭션만 `count=1`. 후속은 `count=0` → `CONFLICT` 반환하며 롤백
- **동작 변경**: 이미 처리된 요청(APPROVED/REJECTED) 재승인 시 `NOT_FOUND` → `CONFLICT` (의미상 더 정확). 프론트엔드 `JoinRequestsSection.tsx`는 `onError` 핸들러가 없어 UX 영향 없음

## Test plan
- [x] `pnpm test` — 240/240 passed (API 20개 test files)
- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [x] `pnpm lint` — 통과
- [x] 신규 통합 테스트 7개 모두 통과
  - TC-1: ADMIN PENDING 승인 → APPROVED + account 갱신 + snapshot 1건
  - TC-2: TEACHER 요청 → FORBIDDEN
  - TC-3: 존재하지 않는 ID → NOT_FOUND
  - TC-4: 다른 조직 요청 → NOT_FOUND
  - TC-5: 이미 APPROVED → CONFLICT
  - TC-6: 이미 REJECTED → CONFLICT
  - **TC-E1 (TOCTOU 핵심)**: 5-way 동시 승인 → 정확히 1건 성공, 4건 CONFLICT, account/snapshot 중복 없음

## Related
- `docs/specs/README.md` TARGET Bugfix P2: 진행중 → ✅ 완료
- 남은 P2 BUGFIX 미착수: 4건 (기존 5건 → 4건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)