### PR TITLE
docs: Rate Limit 주석/정책 문서 불일치 해소

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -135,6 +135,17 @@ throw new TRPCError({
 
 - `~/` → `apps/api/src/` (tsconfig.json에 설정됨)
 
+## Rate Limiting
+
+`apps/api/src/app.ts`에 Express `rateLimit` 전역 미들웨어로 적용. 초과 시 HTTP 429.
+
+| 범위 | 제한 |
+|------|------|
+| 전체 API | IP당 **200회/분** |
+| 인증 (`/trpc/auth`) | IP당 **10회/분** |
+
+헤더: `standardHeaders: 'draft-7'` (RFC 9469 draft).
+
 ## Database
 
 - **ORM**: Prisma + Driver Adapter (`@prisma/adapter-mariadb`)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -48,7 +48,7 @@ export const createApp = (): Express => {
         })
     );
 
-    // Rate Limiting — 전체 API: IP당 100회/분
+    // Rate Limiting — 전체 API: IP당 200회/분 (정책: .claude/rules/api.md)
     app.use(
         rateLimit({
             windowMs: 60 * 1000,

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 |---------------------------|------|---------------------------------------------------------------|
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
-| **Target Bugfix**         | -    | 8건 미착수 (P2 3건, P3 5건) + 9건 완료 |
+| **Target Bugfix**         | -    | 7건 미착수 (P2 3건, P3 4건) + 10건 완료 |
 | **Target Non-Functional** | -    | PERFORMANCE 2건 미착수 + 5건 완료 + DX 2건 완료 |
 
 ## 관련 문서
@@ -91,7 +91,7 @@
 | P2 | 로그인 사용자 열거 공격 | ✅ 완료 | `login.usecase.ts` NOT_FOUND/UNAUTHORIZED 분기를 `UNAUTHORIZED` + 통일 메시지로 단일화. 탈퇴 계정+비번 불일치도 통일. 통합 테스트 10/10 통과 (응답 동일성 검증 TC-E3 추가) |
 | P2 | 입력 검증 강화 | 미착수 | 출석 data 화이트리스트, 로그인 스키마 signup 대비 느슨, 학생 contact·description 길이 무제한 |
 | P2 | 서버측 Excel 파일 재검증 없음 | ✅ 완료 | `bulkCreateStudentItemSchema` 신규(독립). societyName/catholicName max 50, age 1-120, contact `^\d+$` max 15, description max 500, groupIds 1-10. 한글 에러 메시지. 통합 테스트 TC-E5~E10 8건 추가. 단건 경로 무영향 |
-| P3 | Rate Limit 문서/코드 불일치 | 미착수 | 코드 200회/분 vs CLAUDE.md 100회/분. 의도 확인 후 통일 필요 |
+| P3 | Rate Limit 문서/코드 불일치 | ✅ 완료 | 코드 주석 200회/분 정합 + `rules/api.md` Rate Limiting 정책 섹션 신설 (전체 200/분, 인증 10/분) |
 | P3 | StudentGroup deletedAt 미비 | 미착수 | soft-delete 컬럼 없음. 학생 삭제 시 관계 레코드 잔존 |
 | P3 | HTTP 응답 상태코드 일률 200 | 미착수 | 에러 시에도 200 반환. 401/403/404 등 의미 있는 상태코드 필요 |
 | P3 | Express 4.x qs DoS 취약점 | 미착수 | express > qs 저심각도 취약점. Express 5.x 업그레이드로 해결 |


### PR DESCRIPTION
## Summary

- `apps/api/src/app.ts:51` 주석의 `100회/분` 기재를 실제 limit 값 **200회/분**에 정합 (정책 참조 경로 함께 기재)
- `.claude/rules/api.md`에 **Rate Limiting 정책 섹션** 신설 — 전체 API 200/분, 인증(`/trpc/auth`) 10/분, HTTP 429, `draft-7` 헤더
- `docs/specs/README.md` TARGET Bugfix: "Rate Limit 문서/코드 불일치" 완료 처리 (8→7 미착수, 9→10 완료)

## Context

- SDD BUGFIX P3 — `docs/specs/README.md`
- 기존 코드 주석은 `100회/분`, 실제 `express-rate-limit` `limit` 값은 `200` → **실제 운영값을 그대로 유지**하는 방향(옵션 A)으로 결정
- 동작 변경 없음. 문서/주석 정합만 수정

## Test plan

- [x] `pnpm lint:fix && pnpm prettier:fix` — 변경 없음(캐시 히트)
- [x] `pnpm typecheck` — 9/9 성공
- [x] `pnpm test` — 252/252 통과
- [x] Rate Limit 값 변경 없음 → 런타임 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)