### PR TITLE
chore: Prisma Seed 시스템 도입 (로컬 DB drift 방지)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,6 +43,19 @@ pnpm clean              # dist 및 node_modules 정리
 tsc -b -v tsconfig.build.json   # 전체 의존성 순서대로 빌드
 ```
 
+## 로컬 DB 초기화 (Prisma Seed)
+
+```bash
+pnpm --filter @school/api db:reset   # DB 전체 리셋 + seed (drift 정리 시)
+pnpm --filter @school/api db:seed    # 비어있는 DB에 seed만 주입
+```
+
+- Seed 엔트리: `apps/api/prisma/seed.ts`
+- 데이터: Parish 2 / Church 4 / Organization 5 / Account 7 / Group 8 / Student 20 / Registration 10 / Attendance 20
+- 모든 계정 비밀번호: `5678` (로컬 전용)
+- 프로덕션 가드: `NODE_ENV=production`이면 seed 자체가 abort
+- 테스트 DB는 영향받지 않음 (`vitest.global-setup.ts`가 독립적으로 리셋)
+
 ## Coding Style
 
 - **Indentation**: 4 spaces

--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -173,6 +173,10 @@ await database.student.create({
 
 `pnpm prisma generate` (클라이언트+Kysely 타입 생성), `pnpm prisma db push`, `pnpm prisma studio`
 
+### 로컬 DB 리셋 + Seed
+
+`pnpm --filter @school/api db:reset` — `prisma db push --force-reset` + `prisma db seed` 체인. drift 정리 시 사용. `pnpm --filter @school/api db:seed`는 비어있는 DB에 seed만 주입. Seed 엔트리: `apps/api/prisma/seed.ts`, 프로덕션 가드(`NODE_ENV=production` abort) 내장. 테스트 DB와 독립.
+
 ### DB 환경변수
 
 풀: `MYSQL_CONNECTION_LIMIT` (1~100, default 10). 로깅: `DB_QUERY_LOGGING` (off/slow/all, default slow, 슬로우 쿼리 PII 마스킹). 타임아웃(mariadb 어댑터 기본값 명시 보정): `DB_CONNECT_TIMEOUT_MS` (500~30000, default 5000), `DB_IDLE_TIMEOUT_SEC` (60~3600, default 300), `DB_TRANSACTION_TIMEOUT_MS` (1000~60000, default 15000), `DB_TRANSACTION_MAX_WAIT_MS` (500~30000, default 5000). 상세: `.env.example`

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,12 @@
         "dev": "pnpm clean && pnpm build && cross-env NODE_ENV=local node dist/src/app.js",
         "lint": "eslint src",
         "typecheck": "pnpm prisma:generate && tsc --noEmit",
-        "clean": "rimraf dist"
+        "clean": "rimraf dist",
+        "db:seed": "prisma db seed",
+        "db:reset": "prisma db push --force-reset --skip-generate && prisma db seed"
+    },
+    "prisma": {
+        "seed": "tsx prisma/seed.ts"
     },
     "dependencies": {
         "@prisma/adapter-mariadb": "^6.19.2",
@@ -78,6 +83,7 @@
         "globals": "catalog:",
         "prettier": "catalog:",
         "tsc-alias": "^1.8.16",
+        "tsx": "^4.21.0",
         "typescript": "catalog:",
         "vitest": "catalog:"
     },

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,269 @@
+/**
+ * Prisma Seed Script (로컬 개발용)
+ *
+ * 목적: 로컬 DB drift 방지 + 현실적 초기 개발 데이터 자동 생성
+ * 실행: pnpm --filter @school/api db:seed
+ * 초기화 + 시드: pnpm --filter @school/api db:reset
+ *
+ * 프로덕션 실행 가드: NODE_ENV=production 시 즉시 abort.
+ * 모든 계정 비밀번호: TEST_PASSWORD ('5678')
+ *
+ * 데이터 스코프: Parish 2 / Church 4 / Organization 5 / Account 7 / Group 8
+ * / Student 20 / Registration 10 / Attendance 20
+ */
+import { PrismaClient } from '@prisma/client';
+import { getNowKST } from '@school/utils';
+import bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+const TEST_PASSWORD = '5678';
+
+async function main() {
+    if (process.env.NODE_ENV === 'production') {
+        throw new Error('Seed는 프로덕션에서 실행할 수 없습니다. NODE_ENV 확인 필요.');
+    }
+
+    const passwordHash = bcrypt.hashSync(TEST_PASSWORD, 10);
+    const now = getNowKST();
+
+    console.log('🌱 Seed 시작...');
+
+    // Parish
+    const seoul = await prisma.parish.create({ data: { name: '서울대교구', createdAt: now } });
+    const suwon = await prisma.parish.create({ data: { name: '수원교구', createdAt: now } });
+
+    // Church
+    const jangwi = await prisma.church.create({ data: { name: '장위동성당', parishId: seoul.id, createdAt: now } });
+    const heukseok = await prisma.church.create({ data: { name: '흑석동성당', parishId: seoul.id, createdAt: now } });
+    const suwonHq = await prisma.church.create({ data: { name: '수원본당', parishId: suwon.id, createdAt: now } });
+    const bundang = await prisma.church.create({ data: { name: '분당성당', parishId: suwon.id, createdAt: now } });
+
+    // Organization
+    const elementary = await prisma.organization.create({
+        data: { name: '장위동 초등부', type: 'ELEMENTARY', churchId: jangwi.id, createdAt: now },
+    });
+    const middleHigh = await prisma.organization.create({
+        data: { name: '장위동 중고등부', type: 'MIDDLE_HIGH', churchId: jangwi.id, createdAt: now },
+    });
+    const youngAdult = await prisma.organization.create({
+        data: { name: '수원본당 청년부', type: 'YOUNG_ADULT', churchId: suwonHq.id, createdAt: now },
+    });
+    const heukseokOrg = await prisma.organization.create({
+        data: { name: '흑석동 초등부', type: 'ELEMENTARY', churchId: heukseok.id, createdAt: now },
+    });
+    const bundangOrg = await prisma.organization.create({
+        data: { name: '분당 중고등부', type: 'MIDDLE_HIGH', churchId: bundang.id, createdAt: now },
+    });
+
+    // Account (ADMIN 2 + TEACHER 3 + 미소속 1 + pending 1 = 7)
+    const admin = await prisma.account.create({
+        data: {
+            name: 'admin',
+            displayName: '관리자',
+            password: passwordHash,
+            organizationId: middleHigh.id,
+            role: 'ADMIN',
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const teacher1 = await prisma.account.create({
+        data: {
+            name: 'teacher1',
+            displayName: '김교사',
+            password: passwordHash,
+            organizationId: middleHigh.id,
+            role: 'TEACHER',
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const elementaryAdmin = await prisma.account.create({
+        data: {
+            name: 'elemadmin',
+            displayName: '초등부관리자',
+            password: passwordHash,
+            organizationId: elementary.id,
+            role: 'ADMIN',
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const heukseokTeacher = await prisma.account.create({
+        data: {
+            name: 'heukseok',
+            displayName: '흑석선생님',
+            password: passwordHash,
+            organizationId: heukseokOrg.id,
+            role: 'ADMIN',
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const bundangTeacher = await prisma.account.create({
+        data: {
+            name: 'bundang',
+            displayName: '분당선생님',
+            password: passwordHash,
+            organizationId: bundangOrg.id,
+            role: 'ADMIN',
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const orphan = await prisma.account.create({
+        data: {
+            name: 'orphan',
+            displayName: '미소속',
+            password: passwordHash,
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+    const pending = await prisma.account.create({
+        data: {
+            name: 'pending',
+            displayName: '합류대기',
+            password: passwordHash,
+            createdAt: now,
+            privacyAgreedAt: now,
+        },
+    });
+
+    // JoinRequest (pending 1 + approved 1)
+    await prisma.joinRequest.create({
+        data: {
+            accountId: pending.id,
+            organizationId: middleHigh.id,
+            status: 'pending',
+            createdAt: now,
+            updatedAt: now,
+        },
+    });
+    await prisma.joinRequest.create({
+        data: {
+            accountId: teacher1.id,
+            organizationId: middleHigh.id,
+            status: 'approved',
+            createdAt: now,
+            updatedAt: now,
+        },
+    });
+
+    // Group (GRADE 6 + DEPARTMENT 2)
+    const mh1 = await prisma.group.create({ data: { name: '1학년', type: 'GRADE', organizationId: middleHigh.id, createdAt: now } });
+    const mh2 = await prisma.group.create({ data: { name: '2학년', type: 'GRADE', organizationId: middleHigh.id, createdAt: now } });
+    const mh3 = await prisma.group.create({ data: { name: '3학년', type: 'GRADE', organizationId: middleHigh.id, createdAt: now } });
+    const el1 = await prisma.group.create({ data: { name: '1학년', type: 'GRADE', organizationId: elementary.id, createdAt: now } });
+    const el2 = await prisma.group.create({ data: { name: '2학년', type: 'GRADE', organizationId: elementary.id, createdAt: now } });
+    const el3 = await prisma.group.create({ data: { name: '3학년', type: 'GRADE', organizationId: elementary.id, createdAt: now } });
+    const worship = await prisma.group.create({ data: { name: '예절부', type: 'DEPARTMENT', organizationId: middleHigh.id, createdAt: now } });
+    const choir = await prisma.group.create({ data: { name: '성가대', type: 'DEPARTMENT', organizationId: middleHigh.id, createdAt: now } });
+
+    // Student (20)
+    interface StudentDef {
+        societyName: string;
+        catholicName: string | null;
+        gender: 'M' | 'F';
+        age: number;
+        orgId: bigint;
+        groupIds: bigint[];
+    }
+
+    const studentDefs: StudentDef[] = [
+        // 장위동 중고등부 10
+        { societyName: '김민준', catholicName: '베드로', gender: 'M', age: 14, orgId: middleHigh.id, groupIds: [mh1.id] },
+        { societyName: '이서연', catholicName: '마리아', gender: 'F', age: 14, orgId: middleHigh.id, groupIds: [mh1.id, worship.id] },
+        { societyName: '박지호', catholicName: '요한', gender: 'M', age: 14, orgId: middleHigh.id, groupIds: [mh1.id] },
+        { societyName: '최수빈', catholicName: '안나', gender: 'F', age: 15, orgId: middleHigh.id, groupIds: [mh2.id, choir.id] },
+        { societyName: '정윤호', catholicName: null, gender: 'M', age: 15, orgId: middleHigh.id, groupIds: [mh2.id] },
+        { societyName: '강다영', catholicName: '루치아', gender: 'F', age: 15, orgId: middleHigh.id, groupIds: [mh2.id] },
+        { societyName: '조현우', catholicName: '바오로', gender: 'M', age: 16, orgId: middleHigh.id, groupIds: [mh3.id] },
+        { societyName: '윤지우', catholicName: '데레사', gender: 'F', age: 16, orgId: middleHigh.id, groupIds: [mh3.id, worship.id] },
+        { societyName: '한예준', catholicName: '요셉', gender: 'M', age: 16, orgId: middleHigh.id, groupIds: [mh3.id] },
+        { societyName: '오시은', catholicName: '마르타', gender: 'F', age: 16, orgId: middleHigh.id, groupIds: [mh3.id, choir.id] },
+        // 장위동 초등부 7
+        { societyName: '김하늘', catholicName: '토마스', gender: 'M', age: 8, orgId: elementary.id, groupIds: [el1.id] },
+        { societyName: '박서하', catholicName: '아녜스', gender: 'F', age: 8, orgId: elementary.id, groupIds: [el1.id] },
+        { societyName: '이도윤', catholicName: '미카엘', gender: 'M', age: 9, orgId: elementary.id, groupIds: [el2.id] },
+        { societyName: '정아린', catholicName: '클라라', gender: 'F', age: 9, orgId: elementary.id, groupIds: [el2.id] },
+        { societyName: '최건우', catholicName: '프란치스코', gender: 'M', age: 10, orgId: elementary.id, groupIds: [el3.id] },
+        { societyName: '강시온', catholicName: '엘리사벳', gender: 'F', age: 10, orgId: elementary.id, groupIds: [el3.id] },
+        { societyName: '윤지안', catholicName: null, gender: 'M', age: 10, orgId: elementary.id, groupIds: [el3.id] },
+        // 흑석동 초등부 2 (그룹 없음 — 다양성)
+        { societyName: '조하린', catholicName: '세실리아', gender: 'F', age: 8, orgId: heukseokOrg.id, groupIds: [] },
+        { societyName: '김은호', catholicName: '스테파노', gender: 'M', age: 9, orgId: heukseokOrg.id, groupIds: [] },
+        // 분당 중고등부 1
+        { societyName: '이지유', catholicName: '엘레나', gender: 'F', age: 14, orgId: bundangOrg.id, groupIds: [] },
+    ];
+
+    const studentIds: bigint[] = [];
+    for (const s of studentDefs) {
+        const created = await prisma.student.create({
+            data: {
+                societyName: s.societyName,
+                catholicName: s.catholicName,
+                gender: s.gender,
+                age: BigInt(s.age),
+                organizationId: s.orgId,
+                createdAt: now,
+            },
+        });
+        studentIds.push(created.id);
+        for (const gId of s.groupIds) {
+            await prisma.studentGroup.create({
+                data: { studentId: created.id, groupId: gId, createdAt: now },
+            });
+        }
+    }
+
+    // Registration — 현재 연도 앞 10명
+    const currentYear = new Date().getFullYear();
+    for (let i = 0; i < 10; i++) {
+        await prisma.registration.create({
+            data: {
+                studentId: studentIds[i],
+                year: currentYear,
+                registeredAt: now,
+                createdAt: now,
+                updatedAt: now,
+            },
+        });
+    }
+
+    // Attendance — 최근 4주 × 5명 샘플
+    const attendanceMarks = ['◎', '○', '△', '-', '◎'];
+    for (let i = 0; i < 5; i++) {
+        for (let w = 0; w < 4; w++) {
+            const dt = new Date(now);
+            dt.setDate(dt.getDate() - w * 7);
+            const dateStr = `${dt.getFullYear()}${String(dt.getMonth() + 1).padStart(2, '0')}${String(dt.getDate()).padStart(2, '0')}`;
+            await prisma.attendance.create({
+                data: {
+                    studentId: studentIds[i],
+                    date: dateStr,
+                    content: attendanceMarks[(i + w) % attendanceMarks.length],
+                    groupId: mh1.id,
+                    createdAt: now,
+                },
+            });
+        }
+    }
+
+    console.log('✅ Seed 완료');
+    console.log(`   Parish 2 / Church 4 / Organization 5`);
+    console.log(`   Account 7 / JoinRequest 2`);
+    console.log(`   Group 8 / Student ${studentDefs.length} / Registration 10 / Attendance 20`);
+    console.log(`   계정 이름: admin, teacher1, elemadmin, heukseok, bundang, orphan, pending`);
+    console.log(`   비밀번호 (모두): ${TEST_PASSWORD}`);
+}
+
+main()
+    .catch((e) => {
+        console.error('❌ Seed 실패:', e);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 | **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
 | **Target Functional**     | -    | 6건 미착수 |
 | **Target Bugfix**         | -    | 5건 미착수 (P2 2건, P3 3건) + 12건 완료 |
-| **Target Non-Functional** | -    | PERFORMANCE 1건 미착수 + 6건 완료 + DX 2건 완료 |
+| **Target Non-Functional** | -    | PERFORMANCE 1건 미착수 + 6건 완료 / DX 3건 완료 |
 
 ## 관련 문서
 
@@ -102,6 +102,7 @@
 |------|---------------------------|--------|---------------------------------------------------------|
 | P2   | Stitch MCP 서버 연동          | ✅ 완료   | `.mcp.json` 설정 추가. Claude Code에서 Stitch MCP 프록시 연동 |
 | P1   | 통합테스트 실제 DB 전환       | ✅ 완료   | mock 전면 제거 → Docker MySQL + 실제 DB 기반 통합테스트. Prisma 공식 가이드 준수 |
+| P1   | Prisma Seed 시스템 도입 | ✅ 완료 | `apps/api/prisma/seed.ts` 작성 + `db:reset`/`db:seed` 스크립트. Parish 2 / Church 4 / Organization 5 / Account 7 / Group 8 / Student 20 / Registration 10 / Attendance 20 초기 데이터. 프로덕션 가드 내장. `CLAUDE.md`·`rules/api.md` 갱신 |
 
 **Stitch MCP 서버 연동:**
 - Google Stitch: AI 기반 UI 디자인 도구 (텍스트→UI+HTML/CSS)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,12 +228,15 @@ importers:
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
+        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/web:
     dependencies:
@@ -330,7 +333,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.7.0(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -351,10 +354,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
+        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/shared:
     dependencies:
@@ -461,7 +464,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
+        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -629,8 +632,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -641,8 +656,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -653,8 +680,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -665,8 +704,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -677,8 +728,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -689,8 +752,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -701,8 +776,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -713,8 +800,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -725,8 +824,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -737,8 +848,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -749,8 +872,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -761,8 +896,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -773,8 +920,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2792,6 +2951,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4131,6 +4295,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.7.5:
     resolution: {integrity: sha512-nN3wfLLj4OES/7awYyyM7fkU8U8sAFxsXau2bYJwAWi6T09jd87DgHD8N31zXaJ7LcpyppHWPRI2Ov9MuZEwnQ==}
     cpu: [x64]
@@ -4605,79 +4774,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
@@ -6190,7 +6437,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -6198,7 +6445,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6211,13 +6458,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -6767,6 +7014,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -8134,6 +8410,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.7.5:
     optional: true
 
@@ -8249,7 +8532,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8262,11 +8545,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2):
+  vitest@4.0.18(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -8283,7 +8567,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.9


### PR DESCRIPTION
## Summary

- 로컬 DB drift 재발 방지를 위한 **Prisma Seed 시스템** 도입
- `pnpm --filter @school/api db:reset` 1커맨드로 clean 상태 복원
- 2026-04-24 `student-extra-fields` 작업 중 발견된 drift(`group.account_id` 레거시 + `account.name` UNIQUE 미적용)가 트리거

## Changes

- **`apps/api/prisma/seed.ts`** 신규: Parish 2 / Church 4 / Organization 5 / Account 7 / JoinRequest 2 / Group 8 / Student 20 / Registration 10 / Attendance 20
- **`apps/api/package.json`**: `db:reset` / `db:seed` 스크립트 + `prisma.seed` 설정 (`tsx prisma/seed.ts`) + `tsx` 4.21.0 devDependency
- **`.claude/CLAUDE.md`**: "로컬 DB 초기화 (Prisma Seed)" 섹션 추가
- **`.claude/rules/api.md`**: Prisma 섹션에 `db:reset` / `db:seed` 명령 추가
- **`docs/specs/README.md`**: DX TARGET "Prisma Seed 시스템 도입" 완료 마크

## 안전 장치

- `NODE_ENV=production` 시 seed 자체가 abort (운영 실수 방지)
- 모든 계정 비밀번호: `5678` (로컬 전용)
- 테스트 DB는 영향받지 않음 (`vitest.global-setup.ts` 독립 리셋)

## Test plan

- [x] `pnpm --filter @school/api typecheck` 통과
- [x] `pnpm --filter @school/api db:reset` 성공 (데이터 건수 검증 완료)
- [ ] 머지 후 다른 개발자가 `pnpm db:reset`으로 온보딩 가능 확인
- [ ] seed 계정(`admin` / `5678`)으로 로컬 로그인 → 대시보드 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)