### PR TITLE
fix: Docker prod 빌드 시 husky prepare 훅 실패 방지

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "turbo run lint -- --fix",
     "prettier": "prettier --check \"**/*.ts\"",
     "prettier:fix": "prettier --write \"**/*.ts\"",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "author": "dc-choi",
   "license": "",


### PR DESCRIPTION
## Summary
- `pnpm install --frozen-lockfile --prod`가 devDep인 `husky`를 건너뛰어 `prepare` 단계에서 `husky: not found`로 Docker 빌드가 중단되던 문제 해결
- husky 공식 권장 패턴대로 `"prepare": "husky || true"` 적용 (husky가 없으면 조용히 통과)
- PR #269 머지 후 실제 배포 빌드에서 회귀 확인되어 즉시 수정

## Test plan
- [ ] `docker build .` 이 `pnpm install --prod` 단계를 통과하는지
- [ ] 개발 환경에서 `pnpm install` 시 `.husky/` 훅이 여전히 정상 활성화되는지 (`git config core.hooksPath` → `.husky/_`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)