### PR TITLE
fix: Attendance 테이블 복합 인덱스 추가

### DIFF
--- a/apps/api/prisma/migrations/20260425/add_attendance_indexes.sql
+++ b/apps/api/prisma/migrations/20260425/add_attendance_indexes.sql
@@ -1,0 +1,25 @@
+-- Migration: Add composite indexes to attendance
+-- Date: 2026-04-25
+-- Feature: attendance-index (P2 BUGFIX — Attendance 테이블 인덱스 누락)
+-- Description:
+--   attendance 테이블은 보조 인덱스가 전혀 없어 캘린더·일상세·자동저장·통계 쿼리가
+--   풀테이블 스캔으로 동작한다. 장기 성장(MAO 50→200곳) 대비 복합 인덱스 2개 선제 도입.
+--   - (student_id, date): get-calendar / get-day-detail / update-attendance 커버
+--   - (group_id, date): get-attendance-rate / get-group-statistics / get-top-groups 커버
+--   설계: `docs/specs/functional-design/attendance-index.md` (6단계에서 삭제 예정)
+
+-- Up Migration
+CREATE INDEX `attendance_student_id_date_idx` ON `attendance` (`student_id`, `date`);
+CREATE INDEX `attendance_group_id_date_idx`   ON `attendance` (`group_id`,   `date`);
+
+-- Down Migration (rollback)
+-- DROP INDEX `attendance_student_id_date_idx` ON `attendance`;
+-- DROP INDEX `attendance_group_id_date_idx`   ON `attendance`;
+
+-- Notes:
+-- - MySQL 5.6+ 기본 online DDL (ALGORITHM=INPLACE, LOCK=NONE) 지원 → 쓰기 차단 없음
+-- - 현재 테이블 크기 10,561 건 (2026-04-24 기준) → 락 영향 무시 가능
+-- - Leftmost prefix 규칙: student_id 단독 조건도 적중, date 단독은 불적중 (설계 의도)
+-- - deletedAt IS NULL 필터는 인덱스 비포함 (MariaDB/MySQL partial index 미지원)
+--   → EXPLAIN Extra에 "Using where" 표시되나 key 선택은 유지
+-- - YAGNI: (group_id, student_id, date) 성별 통계 커버링은 차후 병목 확인 시 추가

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -235,6 +235,8 @@ model Attendance {
 
     student Student @relation(fields: [studentId], references: [id])
 
+    @@index([studentId, date])
+    @@index([groupId, date])
     @@map("attendance")
 }
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,18 +4,18 @@
 
 ## 문서 현황 요약
 
-| 분류                        | 완성도  | 상세                                                            |
-|---------------------------|------|---------------------------------------------------------------|
-| **Current Functional**    | 100% | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
-| **Target Functional**     | -    | 3건 미착수 |
-| **Target Bugfix**         | -    | 4건 미착수 (P2 1건, P3 3건) + 12건 완료 |
-| **Target Non-Functional** | -    | PERFORMANCE 6건 완료 / DX 3건 완료 |
+| 분류                      | 완성도 | 상세                                                                                                                           |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Current Functional**    | 100%   | 10개 도메인 기능 설계에 통합 + 계정 모델 전환 + 학년/부서 그룹핑 + 게스트 대시보드 + 도네이션 링크 + 도네이션 게스트 접근 완료 |
+| **Target Functional**     | -      | 3건 미착수                                                                                                                     |
+| **Target Bugfix**         | -      | 3건 미착수 (P3 3건) + 13건 완료                                                                                                |
+| **Target Non-Functional** | -      | PERFORMANCE 6건 완료 / DX 3건 완료                                                                                             |
 
 ## 관련 문서
 
-| 문서                           | 설명                                        |
-|------------------------------|-------------------------------------------|
-| `.claude/rules/specs.md`     | SDD 워크플로우 + 문서 작성 규칙                      |
+| 문서                     | 설명                            |
+| ------------------------ | ------------------------------- |
+| `.claude/rules/specs.md` | SDD 워크플로우 + 문서 작성 규칙 |
 
 ---
 
@@ -45,63 +45,66 @@
 
 ### FUNCTIONAL (로드맵 2단계 — 유저 확장 + 가톨릭 특화)
 
-| 우선순위 | 기능명 | SDD 상태 | 비고 |
-|---------|--------|----------|------|
-| P1 | 학생 추가 필드 (부모님 연락처) | ✅ 완료 | `Student/StudentSnapshot.parent_contact VARCHAR(20)` + Zod `/^[\d\-()\s]*$/` max 20. 3 UseCase + 7 snapshot 호출 + 6 응답 경로 갱신. 엑셀 10번째 컬럼 하위 호환. 통합 8건 + 웹 6건 테스트. 생년월일은 별도 과제로 분리. 설계: `student-management.md` |
-| P1 | 출석부 UI 개편 | 미착수 | 출석부 UI 전면 개편 (다수 피드백). 범위 정의 필요 |
-| P1 | 출석 페이지 전체 그룹 학생 확인 | 미착수 | 출석 페이지에서 전체 그룹 학생 조회. "빠른 조회" 핵심 가치 직결 |
-| P2 | 조직/권한 세분화 | 미착수 | 선생님 명단 관리 (수색 피드백). 로드맵 3단계 조직/권한 연동은 2단계에서 완료됨 — 실제 스코프 재정의 필요 |
+| 우선순위 | 기능명                          | SDD 상태 | 비고                                                                                                                                                                                                                                                  |
+| -------- | ------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | 학생 추가 필드 (부모님 연락처)  | ✅ 완료  | `Student/StudentSnapshot.parent_contact VARCHAR(20)` + Zod `/^[\d\-()\s]*$/` max 20. 3 UseCase + 7 snapshot 호출 + 6 응답 경로 갱신. 엑셀 10번째 컬럼 하위 호환. 통합 8건 + 웹 6건 테스트. 생년월일은 별도 과제로 분리. 설계: `student-management.md` |
+| P1       | 출석부 UI 개편                  | 미착수   | 출석부 UI 전면 개편 (다수 피드백). 범위 정의 필요                                                                                                                                                                                                     |
+| P1       | 출석 페이지 전체 그룹 학생 확인 | 미착수   | 출석 페이지에서 전체 그룹 학생 조회. "빠른 조회" 핵심 가치 직결                                                                                                                                                                                       |
+| P2       | 조직/권한 세분화                | 미착수   | 선생님 명단 관리 (수색 피드백). 로드맵 3단계 조직/권한 연동은 2단계에서 완료됨 — 실제 스코프 재정의 필요                                                                                                                                              |
 
 > NFC 출석 파일럿, 축일 관리는 로드맵 재편(2026-04-24)에 따라 TARGET에서 제외. NFC는 하드웨어 검증 대기 중 보류, 축일 관리는 3단계 베이직 플랜으로 이월. 상세: `docs/business/6_roadmap/roadmap.md`
 
 **의존성 체인:**
+
 - 행사 메모 카드: 계정 모델 전환 완료 + 수요 검증 2곳 후 등록 (`docs/brainstorm/2026-02-23.md`)
 
 **SDD 문서 작성 시 경로:**
+
 - Task: `docs/specs/target/functional/tasks/{name}.md`
 - Development: `docs/specs/target/functional/development/{name}-{role}.md` (role: backend, frontend, design)
 
 ### PERFORMANCE (Non-Functional)
 
-| 우선순위 | 기능명                       | SDD 상태 | 비고                                                       |
-|------|---------------------------|--------|---------------------------------------------------------|
-| P1   | 통계 쿼리 전체 메모리 로드          | ✅ 완료    | 4개 UseCase Kysely `GROUP BY` + `SUM(CASE)` 전환. `PRESENT_COUNT_SQL` 헬퍼 추가. 통합 테스트 20/20 통과 |
-| P2   | Organization 목록 페이지네이션 미구현 | ✅ 완료 | skip/take 페이지네이션 + Pagination 컴포넌트 적용                       |
-| P2   | DB connectionLimit 환경변수화 | ✅ 완료    | `MYSQL_CONNECTION_LIMIT` 추가(선택, default 10 — Prisma v7 표준). 검증 1~100. 단위 테스트 8/8 통과 |
-| P3   | 프로덕션 쿼리 로깅 비활성화          | ✅ 완료    | `DB_QUERY_LOGGING` 환경변수(off/slow/all) + 슬로우 쿼리 PII 마스킹. 단위 테스트 13/13 통과 |
-| P3   | 트랜잭션/쿼리 타임아웃 미설정         | ✅ 완료    | 4종 타임아웃 env 명시화 (`DB_CONNECT_TIMEOUT_MS`/`DB_IDLE_TIMEOUT_SEC`/`DB_TRANSACTION_TIMEOUT_MS`/`DB_TRANSACTION_MAX_WAIT_MS`). 어댑터 암묵 기본값(1s/1800s) 보정, Prisma v6 쿼리엔진 기본값과 매칭. 설계: `docs/specs/functional-design/db-timeout.md` |
-| P3   | AuthLayout 이미지 dimensions 누락 | ✅ 완료 | 부재 자산 신규 캡처(1440×900) + width/height/decoding 명시 → CLS 0. 사회적 증거 위치 상향(작은 데스크톱 viewport 노출 보장). 설계: `auth-layout-cls.md` |
+| 우선순위 | 기능명                                | SDD 상태 | 비고                                                                                                                                                                                                                                                      |
+| -------- | ------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | 통계 쿼리 전체 메모리 로드            | ✅ 완료  | 4개 UseCase Kysely `GROUP BY` + `SUM(CASE)` 전환. `PRESENT_COUNT_SQL` 헬퍼 추가. 통합 테스트 20/20 통과                                                                                                                                                   |
+| P2       | Organization 목록 페이지네이션 미구현 | ✅ 완료  | skip/take 페이지네이션 + Pagination 컴포넌트 적용                                                                                                                                                                                                         |
+| P2       | DB connectionLimit 환경변수화         | ✅ 완료  | `MYSQL_CONNECTION_LIMIT` 추가(선택, default 10 — Prisma v7 표준). 검증 1~100. 단위 테스트 8/8 통과                                                                                                                                                        |
+| P3       | 프로덕션 쿼리 로깅 비활성화           | ✅ 완료  | `DB_QUERY_LOGGING` 환경변수(off/slow/all) + 슬로우 쿼리 PII 마스킹. 단위 테스트 13/13 통과                                                                                                                                                                |
+| P3       | 트랜잭션/쿼리 타임아웃 미설정         | ✅ 완료  | 4종 타임아웃 env 명시화 (`DB_CONNECT_TIMEOUT_MS`/`DB_IDLE_TIMEOUT_SEC`/`DB_TRANSACTION_TIMEOUT_MS`/`DB_TRANSACTION_MAX_WAIT_MS`). 어댑터 암묵 기본값(1s/1800s) 보정, Prisma v6 쿼리엔진 기본값과 매칭. 설계: `docs/specs/functional-design/db-timeout.md` |
+| P3       | AuthLayout 이미지 dimensions 누락     | ✅ 완료  | 부재 자산 신규 캡처(1440×900) + width/height/decoding 명시 → CLS 0. 사회적 증거 위치 상향(작은 데스크톱 viewport 노출 보장). 설계: `auth-layout-cls.md`                                                                                                   |
 
 ### BUGFIX
 
-| 우선순위 | 기능명 | SDD 상태 | 비고 |
-|---------|--------|----------|------|
-| P1 | 학생 수정 시 삭제된 그룹 ID로 FORBIDDEN 에러 | ✅ 완료 | student.get에 deletedAt 필터 추가. 군종교구 피드백 |
-| P1 | TRPCError 삼킴 — catch 블록 패턴 누락 | ✅ 완료 | 7개 UseCase catch 블록에 `if (e instanceof TRPCError) throw e` 패턴 추가 완료 |
-| P1 | RefreshToken createdAt UTC/KST 불일치 | ✅ 완료 | 5개 파일 8개 지점 `new Date()` → `getNowKST()` 통일 완료 |
-| P2 | ApproveJoinUseCase TOCTOU 레이스 컨디션 | ✅ 완료 | `updateMany(status=PENDING)` 조건부 업데이트로 트랜잭션 내 원자성 확보. 동시 승인 시 1건만 성공, 후속 요청 CONFLICT. 통합 테스트 7/7 통과 (TC-E1 5-way race 포함) |
-| P2 | Attendance 테이블 인덱스 누락 | 미착수 | studentId, date 인덱스 없음. 데이터 증가 시 성능 저하 |
-| P3 | Attendance 중복 레코드 방지 | 보류 (Watch) | (studentId, date) 유니크 제약 부재. `update-attendance.usecase.ts:130-163`에서 트랜잭션 내 findFirst→create/updateMany로 단일 세션 race 차단. 교차 세션 동시 입력은 이론상 가능하나 실측 중복 미발생. 발생 시 즉시 착수 |
-| P1 | Account.name DB 유니크 제약 미비 | ✅ 완료 | `@unique` + 마이그레이션 SQL + signup P2002 캐치 추가. 활성·탈퇴 전체 적용(탈퇴 name은 restoreAccount 예약). 통합 테스트 237/237 통과 (auth.signup 신규 4건: 정상·앱감지·탈퇴중복·race) |
-| P1 | xlsx 라이브러리 보안 취약점 | ✅ 완료 | Prototype Pollution + ReDoS 2건 → ExcelJS 교체 + 동적 import 분리 |
-| P1 | 출석 배열 상한 미설정 (DoS) | ✅ 완료 | `.max(500)` 추가. 중복 빈 배열 체크 제거, 테스트 추가 |
-| P2 | 로그인 사용자 열거 공격 | ✅ 완료 | `login.usecase.ts` NOT_FOUND/UNAUTHORIZED 분기를 `UNAUTHORIZED` + 통일 메시지로 단일화. 탈퇴 계정+비번 불일치도 통일. 통합 테스트 10/10 통과 (응답 동일성 검증 TC-E3 추가) |
-| P2 | 입력 검증 강화 | ✅ 완료 | 출석 `data` 화이트리스트(◎/○/△/-/빈/max 10) + 로그인 `name`(max 50)·`password`(max 128) + 학생 단건 `societyName`·`catholicName`(max 50)·`contact`(`^\d+$`/max 15)·`description`(max 500). 단건/일괄 경로 일관성 확보. 통합 테스트 18건 추가 (api 270/270 통과) |
-| P2 | 서버측 Excel 파일 재검증 없음 | ✅ 완료 | `bulkCreateStudentItemSchema` 신규(독립). societyName/catholicName max 50, age 1-120, contact `^\d+$` max 15, description max 500, groupIds 1-10. 한글 에러 메시지. 통합 테스트 TC-E5~E10 8건 추가. 단건 경로 무영향 |
-| P3 | Rate Limit 문서/코드 불일치 | ✅ 완료 | 코드 주석 200회/분 정합 + `rules/api.md` Rate Limiting 정책 섹션 신설 (전체 200/분, 인증 10/분) |
-| P3 | HTTP 응답 상태코드 일률 200 | ✅ 완료 | tRPC `responseMeta`로 첫 에러 `data.httpStatus` 매핑(단일/배치 공통). 에러 미들웨어 단순화 + `ApiError`/`ApiCode`/`ApiMessage` dead code 제거. 통합 테스트 8건 추가(TC-1~5, TC-E1~E2). 클라이언트 silent refresh 정상 동작 |
-| P3 | Express 4.x qs DoS 취약점 | 미착수 | **보안 유지 항목**. express > qs Prototype Pollution 계열. rate limit 200/분으로 표층 공격 경감되나 보안 기본 원칙상 업그레이드 경로 유지. Express 5.x 마이그레이션 대규모 breaking change — 별도 사이클 계획 필요 |
-| P3 | Student.contact 타입 이관 | 미착수 | `contact BigInt` → `String`. 선행 0 잘림 잠재 버그 (`01012345678` → `1012345678`로 저장). `parentContact`(`student-extra-fields`) 도입으로 타입 일관성 이슈 부각 — 포매팅 분리 전략으로 통일. 기존 데이터 이관 필요 (활성 학생 2,676명 대상) |
+| 우선순위 | 기능명                                       | SDD 상태     | 비고                                                                                                                                                                                                                                                            |
+| -------- | -------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | 학생 수정 시 삭제된 그룹 ID로 FORBIDDEN 에러 | ✅ 완료      | student.get에 deletedAt 필터 추가. 군종교구 피드백                                                                                                                                                                                                              |
+| P1       | TRPCError 삼킴 — catch 블록 패턴 누락        | ✅ 완료      | 7개 UseCase catch 블록에 `if (e instanceof TRPCError) throw e` 패턴 추가 완료                                                                                                                                                                                   |
+| P1       | RefreshToken createdAt UTC/KST 불일치        | ✅ 완료      | 5개 파일 8개 지점 `new Date()` → `getNowKST()` 통일 완료                                                                                                                                                                                                        |
+| P2       | ApproveJoinUseCase TOCTOU 레이스 컨디션      | ✅ 완료      | `updateMany(status=PENDING)` 조건부 업데이트로 트랜잭션 내 원자성 확보. 동시 승인 시 1건만 성공, 후속 요청 CONFLICT. 통합 테스트 7/7 통과 (TC-E1 5-way race 포함)                                                                                               |
+| P2       | Attendance 테이블 인덱스 누락                | ✅ 완료      | 복합 인덱스 2개 추가: `(student_id, date)` + `(group_id, date)`. 캘린더·일상세·자동저장·통계 쿼리 커버. online DDL로 무중단 적용. 통합 테스트 290/290 통과                                                                                                      |
+| P3       | Attendance 중복 레코드 방지                  | 보류 (Watch) | (studentId, date) 유니크 제약 부재. `update-attendance.usecase.ts:130-163`에서 트랜잭션 내 findFirst→create/updateMany로 단일 세션 race 차단. 교차 세션 동시 입력은 이론상 가능하나 실측 중복 미발생. 발생 시 즉시 착수                                         |
+| P1       | Account.name DB 유니크 제약 미비             | ✅ 완료      | `@unique` + 마이그레이션 SQL + signup P2002 캐치 추가. 활성·탈퇴 전체 적용(탈퇴 name은 restoreAccount 예약). 통합 테스트 237/237 통과 (auth.signup 신규 4건: 정상·앱감지·탈퇴중복·race)                                                                         |
+| P1       | xlsx 라이브러리 보안 취약점                  | ✅ 완료      | Prototype Pollution + ReDoS 2건 → ExcelJS 교체 + 동적 import 분리                                                                                                                                                                                               |
+| P1       | 출석 배열 상한 미설정 (DoS)                  | ✅ 완료      | `.max(500)` 추가. 중복 빈 배열 체크 제거, 테스트 추가                                                                                                                                                                                                           |
+| P2       | 로그인 사용자 열거 공격                      | ✅ 완료      | `login.usecase.ts` NOT_FOUND/UNAUTHORIZED 분기를 `UNAUTHORIZED` + 통일 메시지로 단일화. 탈퇴 계정+비번 불일치도 통일. 통합 테스트 10/10 통과 (응답 동일성 검증 TC-E3 추가)                                                                                      |
+| P2       | 입력 검증 강화                               | ✅ 완료      | 출석 `data` 화이트리스트(◎/○/△/-/빈/max 10) + 로그인 `name`(max 50)·`password`(max 128) + 학생 단건 `societyName`·`catholicName`(max 50)·`contact`(`^\d+$`/max 15)·`description`(max 500). 단건/일괄 경로 일관성 확보. 통합 테스트 18건 추가 (api 270/270 통과) |
+| P2       | 서버측 Excel 파일 재검증 없음                | ✅ 완료      | `bulkCreateStudentItemSchema` 신규(독립). societyName/catholicName max 50, age 1-120, contact `^\d+$` max 15, description max 500, groupIds 1-10. 한글 에러 메시지. 통합 테스트 TC-E5~E10 8건 추가. 단건 경로 무영향                                            |
+| P3       | Rate Limit 문서/코드 불일치                  | ✅ 완료      | 코드 주석 200회/분 정합 + `rules/api.md` Rate Limiting 정책 섹션 신설 (전체 200/분, 인증 10/분)                                                                                                                                                                 |
+| P3       | HTTP 응답 상태코드 일률 200                  | ✅ 완료      | tRPC `responseMeta`로 첫 에러 `data.httpStatus` 매핑(단일/배치 공통). 에러 미들웨어 단순화 + `ApiError`/`ApiCode`/`ApiMessage` dead code 제거. 통합 테스트 8건 추가(TC-1~5, TC-E1~E2). 클라이언트 silent refresh 정상 동작                                      |
+| P3       | Express 4.x qs DoS 취약점                    | 미착수       | **보안 유지 항목**. express > qs Prototype Pollution 계열. rate limit 200/분으로 표층 공격 경감되나 보안 기본 원칙상 업그레이드 경로 유지. Express 5.x 마이그레이션 대규모 breaking change — 별도 사이클 계획 필요                                              |
+| P3       | Student.contact 타입 이관                    | 미착수       | `contact BigInt` → `String`. 선행 0 잘림 잠재 버그 (`01012345678` → `1012345678`로 저장). `parentContact`(`student-extra-fields`) 도입으로 타입 일관성 이슈 부각 — 포매팅 분리 전략으로 통일. 기존 데이터 이관 필요 (활성 학생 2,676명 대상)                    |
 
 ### DX (Non-Functional)
 
-| 우선순위 | 기능명                       | SDD 상태 | 비고                                                       |
-|------|---------------------------|--------|---------------------------------------------------------|
-| P2   | Stitch MCP 서버 연동          | ✅ 완료   | `.mcp.json` 설정 추가. Claude Code에서 Stitch MCP 프록시 연동 |
-| P1   | 통합테스트 실제 DB 전환       | ✅ 완료   | mock 전면 제거 → Docker MySQL + 실제 DB 기반 통합테스트. Prisma 공식 가이드 준수 |
-| P1   | Prisma Seed 시스템 도입 | ✅ 완료 | `apps/api/prisma/seed.ts` 작성 + `db:reset`/`db:seed` 스크립트. Parish 2 / Church 4 / Organization 5 / Account 7 / Group 8 / Student 20 / Registration 10 / Attendance 20 초기 데이터. 프로덕션 가드 내장. `CLAUDE.md`·`rules/api.md` 갱신 |
+| 우선순위 | 기능명                  | SDD 상태 | 비고                                                                                                                                                                                                                                       |
+| -------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P2       | Stitch MCP 서버 연동    | ✅ 완료  | `.mcp.json` 설정 추가. Claude Code에서 Stitch MCP 프록시 연동                                                                                                                                                                              |
+| P1       | 통합테스트 실제 DB 전환 | ✅ 완료  | mock 전면 제거 → Docker MySQL + 실제 DB 기반 통합테스트. Prisma 공식 가이드 준수                                                                                                                                                           |
+| P1       | Prisma Seed 시스템 도입 | ✅ 완료  | `apps/api/prisma/seed.ts` 작성 + `db:reset`/`db:seed` 스크립트. Parish 2 / Church 4 / Organization 5 / Account 7 / Group 8 / Student 20 / Registration 10 / Attendance 20 초기 데이터. 프로덕션 가드 내장. `CLAUDE.md`·`rules/api.md` 갱신 |
 
 **Stitch MCP 서버 연동:**
+
 - Google Stitch: AI 기반 UI 디자인 도구 (텍스트→UI+HTML/CSS)
 - MCP 서버/SDK로 Claude Code 연동 가능
 - SDD 2단계(기능 설계) 와이어프레임 자동화 목적
@@ -113,10 +116,9 @@
 
 ### 작성자 (PRD/기능 설계/SDD)
 
-| 문서 유형       | 경로                                          |
-|-------------|---------------------------------------------|
+| 문서 유형   | 경로                                        |
+| ----------- | ------------------------------------------- |
 | PRD         | `docs/specs/templates/prd.md`               |
-| 기능 설계       | `docs/specs/templates/functional_design.md` |
+| 기능 설계   | `docs/specs/templates/functional_design.md` |
 | Task        | `docs/specs/templates/task.md`              |
 | Development | `docs/specs/templates/development.md`       |
-


### PR DESCRIPTION
## Summary
`attendance` 테이블에 복합 인덱스 2개(`(student_id, date)`, `(group_id, date)`)를 추가하여 캘린더·일상세·자동저장·업데이트·통계 쿼리의 풀테이블 스캔을 제거했다. MySQL online DDL(`ALGORITHM=INPLACE, LOCK=NONE` 기본) 지원 범위 내 무중단 적용이며, 현재 10,561건 규모에서 락 영향은 무시 수준. `docs/specs/README.md` TARGET BUGFIX P2 상태를 "✅ 완료"로 갱신했다.

## Test plan
- [x] `SHOW INDEX FROM attendance` — 신규 인덱스 2개 확인
- [x] `EXPLAIN` — Q1(`student_id + date range`) → `range + key=attendance_student_id_date_idx`, Q5(`group_id IN + date range + GROUP BY`) → `index + key=attendance_group_id_date_idx`
- [x] API 통합 테스트 290/290 통과, 빌드/타입체크/린트/prettier 통과
- [ ] 프로덕션 배포 전 `SELECT VERSION();`으로 MySQL 버전 확인 권장 (5.6+ online DDL 전제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)