### PR TITLE
ci: deploy-web SCP 사전 정리 step 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,20 @@ jobs:
           VITE_GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
         run: pnpm turbo build --filter=@school/web
 
+      # SCP는 tar 압축해제 시 기존 디렉토리에 utime/chmod를 시도하므로,
+      # 다른 소유자/권한으로 만들어진 신규 디렉토리(icons, assets 등)에서
+      # "Operation not permitted" 에러로 배포가 실패할 수 있다.
+      # 새 정적 디렉토리 추가 직후 한 번 정리 → 이후 배포는 안정적.
+      - name: Pre-clean static dirs (avoid SCP utime/chmod conflicts)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            cd ${{ secrets.WEB_DEPLOY_PATH }}
+            rm -rf icons
+
       - name: Deploy to server via SCP
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
## Summary

- `deploy-web` job의 SCP 직전에 `ssh-action`으로 신규 정적 디렉토리(`icons`) 사전 정리 step 추가
- SCP tar 압축해제가 기존 디렉토리의 utime/chmod를 시도하여 "Operation not permitted" 에러로 배포 실패하는 케이스 사전 차단
- 향후 새 정적 디렉토리 추가 시 동일 패턴으로 항목 추가 (코멘트 명시)

## Background

PR #300 (PWA 모바일 가이드) 첫 배포 시 `apps/web/public/icons/` 신규 디렉토리가 서버 권한 충돌로 실패:

```
tar: icons: Cannot utime: Operation not permitted
tar: icons: Cannot change mode to rwxr-xr-x: Operation not permitted
```

서버에서 1회 `rm -rf icons` 정리로 우회했으나, 같은 패턴이 다음 신규 정적 디렉토리 추가 시 재발 가능. 이번 PR에서 사전 정리 step으로 근본 차단.

## Test plan

- [ ] main 머지 후 다음 web 배포에서 `Pre-clean static dirs` step 정상 실행 확인
- [ ] icons 정리 후 SCP 압축해제가 utime/chmod 에러 없이 통과하는지 확인
- [ ] nginx serve 중단 시간 무시 가능한 수준(수십ms)인지 확인

## Notes

- 더 근본 해결로 SCP → rsync(`--no-perms --no-times`) 전환 또는 atomic deploy(임시 디렉토리 + mv swap) 도입 가능. 본 PR은 작은 비용으로 즉시 차단하는 패치.
- 새 정적 디렉토리 추가 시 코멘트의 패턴대로 `rm -rf <new-dir>` 항목 추가 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)