### PR TITLE
feat: Microsoft Clarity 세션 리플레이 도입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Build web
         env:
           VITE_GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
+          VITE_CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
         run: pnpm turbo build --filter=@school/web
 
       # SCP는 tar 압축해제 시 기존 디렉토리에 utime/chmod를 시도하므로,

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -67,6 +67,21 @@
         }
       })();
     </script>
+
+    <!-- Microsoft Clarity (세션 리플레이) -->
+    <!-- 미성년자(학생) PII 보호: 마스킹 모드는 Clarity 대시보드 > Settings > Masking 에서 -->
+    <!-- 반드시 "Strict"(모든 텍스트/입력 마스킹)로 설정한다. 코드가 아닌 대시보드 설정값이다. -->
+    <script>
+      (function() {
+        var CLARITY_ID = '%VITE_CLARITY_PROJECT_ID%';
+        if (!CLARITY_ID || CLARITY_ID.indexOf('VITE_') !== -1 || CLARITY_ID.indexOf('%') !== -1) return;
+        (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src='https://www.clarity.ms/tag/'+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, 'clarity', 'script', CLARITY_ID);
+      })();
+    </script>
 </head>
 <body>
     <div id="root"></div>

--- a/apps/web/src/pages/legal/PrivacyPage.tsx
+++ b/apps/web/src/pages/legal/PrivacyPage.tsx
@@ -81,6 +81,8 @@ export function PrivacyPage() {
                 </p>
                 <ul className="mt-2 list-disc space-y-1 pl-6">
                     <li>클라우드 인프라 운영: Amazon Web Services, Inc.</li>
+                    <li>서비스 이용 통계 분석: Google LLC (Google Analytics)</li>
+                    <li>서비스 이용 행태 분석: Microsoft Corporation (Microsoft Clarity)</li>
                 </ul>
             </section>
 
@@ -112,6 +114,10 @@ export function PrivacyPage() {
                 <p className="mt-2">
                     회사는 로그인 상태 유지·서비스 품질 측정 목적으로 쿠키를 사용할 수 있습니다. 정보주체는 브라우저
                     설정을 통해 쿠키 저장을 거부할 수 있으나, 이 경우 일부 서비스 이용에 제한이 있을 수 있습니다.
+                </p>
+                <p className="mt-2">
+                    회사는 서비스 개선과 이용 행태 분석을 위해 Google Analytics, Microsoft Clarity 등 외부 분석 도구를
+                    사용하며, 이 과정에서 쿠키 및 유사 기술을 통해 이용 기록이 수집될 수 있습니다.
                 </p>
             </section>
 


### PR DESCRIPTION
## Summary
- `index.html`: Microsoft Clarity 세션 리플레이 스니펫 추가. `%VITE_CLARITY_PROJECT_ID%` placeholder + 가드 패턴(GA4와 동일) — 시크릿 미설정 시 스니펫 스킵
- `deploy.yml`: "Build web" 스텝에 `VITE_CLARITY_PROJECT_ID` 빌드 환경변수 주입
- `PrivacyPage`: "5. 처리 위탁"에 Google/Microsoft 추가, "8. 쿠키"에 외부 분석 도구 사용 명시
- 마스킹 모드는 코드가 아닌 Clarity 대시보드 설정값 — **Strict** 필수 (미성년자 학생 PII 보호)

## Test plan
- [ ] CI 빌드 통과 (lint/typecheck/test)
- [ ] 배포 후 프로덕션에서 Clarity 스니펫 로드 확인 (네트워크 탭 `clarity.ms/tag/...`)
- [ ] 개인정보처리방침 페이지(`/privacy`)에서 위탁사 목록/쿠키 문구 정상 렌더 확인

## 배포 후 필수 게이트 (머지 ≠ 운영 시작)
- [ ] GitHub Secret `CLARITY_PROJECT_ID` 등록 확인
- [ ] Clarity 대시보드 Masking 모드 = **Strict** 확인
- [ ] 15개 PII 화면 육안 검증 — 학생 실명/연락처/부모 연락처가 리플레이에서 마스킹됨
- [ ] 한 곳이라도 PII 노출 시 즉시 Clarity 일시정지 + 개별 마스킹 보강
- [ ] 검증 통과 전 실데이터 운영 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)