### PR TITLE
feat(dashboard): 날짜 캘린더 추가 + 통계 카드 레이아웃 개선

### DIFF
--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -7,18 +7,23 @@ import { PatronFeastCard } from './PatronFeastCard';
 import { TopRankingCard } from './TopRankingCard';
 import { JOIN_REQUEST_STATUS, ROLE, getOrganizationLabels } from '@school/shared';
 import { getNthSundayOf, getWeeksInMonth } from '@school/utils';
-import { Check } from 'lucide-react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { CalendarIcon, Check } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { MainLayout } from '~/components/layout';
 import { Button } from '~/components/ui/button';
+import { Calendar } from '~/components/ui/calendar';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { Label } from '~/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select';
 import { useAuth } from '~/features/auth';
 import { useDashboardStatistics } from '~/features/statistics';
 import { useOnboardingStatus } from '~/hooks/useOnboardingStatus';
 import { analytics } from '~/lib/analytics';
+import { cn } from '~/lib/utils';
 
 const buildOnboardingSteps = (group: string, member: string) => [
     {
@@ -141,14 +146,23 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
     const currentYear = now.getFullYear();
     const currentMonth = now.getMonth() + 1;
     const [selectedYear, setSelectedYear] = useState(currentYear);
-    const [selectedMonth, setSelectedMonth] = useState<number | undefined>(undefined);
-    const [selectedWeek, setSelectedWeek] = useState<number | undefined>(undefined);
+    const [selectedMonth, setSelectedMonth] = useState<number | undefined>(currentMonth);
+    const [selectedWeek, setSelectedWeek] = useState<number | undefined>(() => {
+        const weeks = getWeeksInMonth(currentYear, currentMonth);
+        for (let w = weeks; w >= 1; w--) {
+            if (getNthSundayOf(currentYear, currentMonth, w) <= now) return w;
+        }
+        return undefined;
+    });
+    const [selectedDay, setSelectedDay] = useState<string | undefined>(() => format(now, 'yyyy-MM-dd'));
 
     const stats = useDashboardStatistics({
         year: selectedYear,
         month: selectedMonth,
         week: selectedWeek,
+        day: selectedDay,
     });
+    const effectiveDay = stats.groupStatistics?.effectiveDay ?? null;
     const hasError = !!stats.error;
 
     // GA4 이벤트: 대시보드 진입
@@ -198,7 +212,7 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
 
     return (
         <MainLayout title={`안녕하세요, ${account?.displayName}님!`}>
-            <div className="flex flex-col gap-3 md:h-[calc(100vh-7.5rem)]">
+            <div className="flex flex-col gap-3">
                 {/* 합류 요청 관리 (admin만) */}
                 {role === ROLE.ADMIN ? <JoinRequestsSection /> : null}
 
@@ -206,7 +220,7 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                 {showContextBanner ? <ContextBanner /> : null}
 
                 {/* 필터 + 전례 시기 카드 — 필터는 모바일 숨김(통계 페이지에 노출), 전례/축일자는 모바일에도 표시 */}
-                <div className="flex flex-col gap-3 md:flex-row md:items-start">
+                <div className="flex flex-col gap-3">
                     <div className="hidden flex-wrap items-center gap-2 md:flex">
                         <Label className="text-xs text-muted-foreground">연도</Label>
                         <Select
@@ -215,9 +229,10 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                                 setSelectedYear(Number(v));
                                 setSelectedMonth(undefined);
                                 setSelectedWeek(undefined);
+                                setSelectedDay(undefined);
                             }}
                         >
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -234,9 +249,10 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                             onValueChange={(v) => {
                                 setSelectedMonth(v ? Number(v) : undefined);
                                 setSelectedWeek(undefined);
+                                setSelectedDay(undefined);
                             }}
                         >
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue placeholder="전체" />
                             </SelectTrigger>
                             <SelectContent>
@@ -250,10 +266,13 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                         <Label className="text-xs text-muted-foreground">주차</Label>
                         <Select
                             value={selectedWeek?.toString() ?? ''}
-                            onValueChange={(v) => setSelectedWeek(v && v !== 'all' ? Number(v) : undefined)}
+                            onValueChange={(v) => {
+                                setSelectedWeek(v && v !== 'all' ? Number(v) : undefined);
+                                setSelectedDay(undefined);
+                            }}
                             disabled={!selectedMonth}
                         >
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue placeholder="전체" />
                             </SelectTrigger>
                             <SelectContent>
@@ -264,13 +283,51 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                                 ))}
                             </SelectContent>
                         </Select>
+                        <Label className="text-xs text-muted-foreground">날짜</Label>
+                        <Popover>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className={cn(
+                                        'h-9 w-[9.5rem] justify-start gap-2 px-2 text-left text-sm font-normal tabular-nums',
+                                        !(selectedDay ?? effectiveDay) && 'text-muted-foreground'
+                                    )}
+                                >
+                                    <CalendarIcon className="size-4 shrink-0" aria-hidden="true" />
+                                    <span className="truncate">
+                                        {(selectedDay ?? effectiveDay)
+                                            ? format(new Date(selectedDay ?? effectiveDay ?? ''), 'yyyy-MM-dd', {
+                                                  locale: ko,
+                                              })
+                                            : '날짜 선택'}
+                                    </span>
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-auto p-0" align="start">
+                                <Calendar
+                                    mode="single"
+                                    selected={
+                                        (selectedDay ?? effectiveDay)
+                                            ? new Date(selectedDay ?? effectiveDay ?? '')
+                                            : undefined
+                                    }
+                                    onSelect={(selected) =>
+                                        setSelectedDay(selected ? format(selected, 'yyyy-MM-dd') : undefined)
+                                    }
+                                    captionLayout="dropdown"
+                                />
+                            </PopoverContent>
+                        </Popover>
                     </div>
 
-                    <div className="md:flex-1">
-                        <LiturgicalSeasonCard />
-                    </div>
-                    <div className="md:flex-1">
-                        <PatronFeastCard />
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start">
+                        <div className="md:flex-1">
+                            <LiturgicalSeasonCard />
+                        </div>
+                        <div className="md:flex-1">
+                            <PatronFeastCard />
+                        </div>
                     </div>
                 </div>
 
@@ -279,7 +336,7 @@ function DashboardContent({ showContextBanner = false }: { showContextBanner?: b
                     data={stats.groupStatistics}
                     isLoading={stats.isLoading}
                     error={hasError}
-                    className="hidden min-h-0 flex-1 md:flex"
+                    className="hidden h-[420px] md:flex"
                 />
 
                 {/* 성별 분포 & 우수 출석 학생 — 모바일 숨김 */}
@@ -307,13 +364,13 @@ function GuestDashboardContent() {
 
     return (
         <MainLayout title="주일학교 출석부">
-            <div className="flex flex-col gap-3 md:h-[calc(100vh-7.5rem)]">
+            <div className="flex flex-col gap-3">
                 {/* 필터 (disabled) + 전례 시기 카드 — 필터/통계 카드는 모바일 숨김 */}
                 <div className="flex flex-col gap-3 md:flex-row md:items-start">
                     <div className="hidden flex-wrap items-center gap-2 md:flex">
                         <Label className="text-xs text-muted-foreground">연도</Label>
                         <Select value={currentYear.toString()} disabled>
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -322,7 +379,7 @@ function GuestDashboardContent() {
                         </Select>
                         <Label className="text-xs text-muted-foreground">월</Label>
                         <Select value="" disabled>
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue placeholder="전체" />
                             </SelectTrigger>
                             <SelectContent>
@@ -331,7 +388,7 @@ function GuestDashboardContent() {
                         </Select>
                         <Label className="text-xs text-muted-foreground">주차</Label>
                         <Select value="" disabled>
-                            <SelectTrigger className="h-9 w-20">
+                            <SelectTrigger className="h-9 w-28">
                                 <SelectValue placeholder="전체" />
                             </SelectTrigger>
                             <SelectContent>
@@ -352,11 +409,11 @@ function GuestDashboardContent() {
                 </div>
 
                 {/* 학년별 통계 — 모바일 숨김 */}
-                <Card className="hidden min-h-0 flex-1 md:block">
-                    <CardHeader>
+                <Card className="hidden h-[420px] md:block">
+                    <CardHeader className="p-4 pb-2">
                         <CardTitle className="text-base">학년별 통계</CardTitle>
                     </CardHeader>
-                    <CardContent>
+                    <CardContent className="p-4 pt-0">
                         <p className="text-sm text-muted-foreground">로그인이 필요합니다</p>
                     </CardContent>
                 </Card>
@@ -364,18 +421,18 @@ function GuestDashboardContent() {
                 {/* 성별 분포 & 우수 출석 학생 — 모바일 숨김 */}
                 <div className="hidden grid-cols-1 gap-3 md:grid md:grid-cols-2">
                     <Card>
-                        <CardHeader>
+                        <CardHeader className="p-4 pb-2">
                             <CardTitle className="text-base">성별 분포</CardTitle>
                         </CardHeader>
-                        <CardContent>
+                        <CardContent className="p-4 pt-0">
                             <p className="text-sm text-muted-foreground">로그인이 필요합니다</p>
                         </CardContent>
                     </Card>
                     <Card>
-                        <CardHeader>
+                        <CardHeader className="p-4 pb-2">
                             <CardTitle className="text-base">전체 우수 출석 학생 TOP 5</CardTitle>
                         </CardHeader>
-                        <CardContent>
+                        <CardContent className="p-4 pt-0">
                             <p className="text-sm text-muted-foreground">로그인이 필요합니다</p>
                         </CardContent>
                     </Card>

--- a/apps/web/src/pages/dashboard/GenderDistributionChart.tsx
+++ b/apps/web/src/pages/dashboard/GenderDistributionChart.tsx
@@ -24,7 +24,7 @@ function GenderContent({
 }) {
     if (isLoading) {
         return (
-            <div className="flex h-[200px] items-center justify-center">
+            <div className="flex h-[110px] items-center justify-center">
                 <LoadingSpinner />
             </div>
         );
@@ -33,14 +33,14 @@ function GenderContent({
     if (chartData.length > 0) {
         return (
             <div className="flex flex-col items-center">
-                <ResponsiveContainer width="100%" height={180}>
+                <ResponsiveContainer width="100%" height={110}>
                     <PieChart>
                         <Pie
                             data={chartData}
                             cx="50%"
                             cy="50%"
-                            innerRadius={40}
-                            outerRadius={70}
+                            innerRadius={22}
+                            outerRadius={42}
                             paddingAngle={2}
                             dataKey="value"
                         >
@@ -81,11 +81,11 @@ export function GenderDistributionChart({ data, isLoading, error }: GenderDistri
     const totalStudents = data ? data.male.count + data.female.count + data.unknown.count : 0;
 
     return (
-        <Card>
-            <CardHeader>
+        <Card className="min-h-0">
+            <CardHeader className="p-4 pb-2">
                 <CardTitle className="text-base">성별 분포</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="p-4 pt-0">
                 <GenderContent
                     chartData={chartData}
                     totalStudents={totalStudents}

--- a/apps/web/src/pages/dashboard/GroupStatisticsTable.tsx
+++ b/apps/web/src/pages/dashboard/GroupStatisticsTable.tsx
@@ -51,12 +51,12 @@ function TotalRow({ groups }: { groups: GroupStatisticsItem[] }) {
 
     return (
         <TableRow className="border-t-2 font-bold">
-            <TableCell className="px-2 py-2 md:px-5 md:py-4">총계</TableCell>
+            <TableCell className="px-2 py-2 md:px-4 md:py-2">총계</TableCell>
             <TableCell className="hidden text-center tabular-nums md:table-cell">{totalStudents}명</TableCell>
             <TableCell className="hidden text-center tabular-nums md:table-cell">{totalRegistered}명</TableCell>
-            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">{dailyTotal}명</TableCell>
-            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">{weeklyAvg}명</TableCell>
-            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">{monthlyAvg}명</TableCell>
+            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">{dailyTotal}명</TableCell>
+            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">{weeklyAvg}명</TableCell>
+            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">{monthlyAvg}명</TableCell>
             <TableCell className="hidden text-center tabular-nums md:table-cell">{yearlyAvg}명</TableCell>
             <TableCell className="hidden text-center tabular-nums md:table-cell">{dailyRate}%</TableCell>
             <TableCell className="hidden text-center tabular-nums md:table-cell">{weeklyRate}%</TableCell>
@@ -89,16 +89,16 @@ function GroupStatisticsContent({ data, isLoading, error }: GroupStatisticsTable
             <Table className="text-sm md:min-w-[600px] md:text-base">
                 <TableHeader className="sticky top-0 z-20 bg-muted/80 backdrop-blur-sm">
                     <TableRow>
-                        <TableHead className="h-10 whitespace-nowrap px-2 md:h-14 md:px-5">{labels.group}명</TableHead>
+                        <TableHead className="h-10 whitespace-nowrap px-2 md:h-11 md:px-4">{labels.group}명</TableHead>
                         <TableHead className="hidden whitespace-nowrap text-center md:table-cell">총 인원</TableHead>
                         <TableHead className="hidden whitespace-nowrap text-center md:table-cell">등록 인원</TableHead>
-                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-14 md:px-5">
+                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-11 md:px-4">
                             일간<span className="hidden md:inline"> 출석</span>
                         </TableHead>
-                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-14 md:px-5">
+                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-11 md:px-4">
                             주간 평균<span className="hidden md:inline"> 출석</span>
                         </TableHead>
-                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-14 md:px-5">
+                        <TableHead className="h-10 whitespace-nowrap px-2 text-center md:h-11 md:px-4">
                             월간 평균<span className="hidden md:inline"> 출석</span>
                         </TableHead>
                         <TableHead className="hidden whitespace-nowrap text-center md:table-cell">
@@ -121,7 +121,7 @@ function GroupStatisticsContent({ data, isLoading, error }: GroupStatisticsTable
                 <TableBody>
                     {data.groups.map((group) => (
                         <TableRow key={group.groupId}>
-                            <TableCell className="px-2 py-2 font-medium md:px-5 md:py-4">
+                            <TableCell className="px-2 py-2 font-medium md:px-4 md:py-2">
                                 {group.groupName}
                                 <Badge
                                     variant={group.groupType === GROUP_TYPE.GRADE ? 'default' : 'secondary'}
@@ -136,13 +136,13 @@ function GroupStatisticsContent({ data, isLoading, error }: GroupStatisticsTable
                             <TableCell className="hidden text-center tabular-nums md:table-cell">
                                 {group.registeredStudents}명
                             </TableCell>
-                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">
+                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">
                                 {group.daily.attendanceCount}명
                             </TableCell>
-                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">
+                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">
                                 {group.weekly.avgAttendance}명
                             </TableCell>
-                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-5 md:py-4">
+                            <TableCell className="px-2 py-2 text-center tabular-nums md:px-4 md:py-2">
                                 {group.monthly.avgAttendance}명
                             </TableCell>
                             <TableCell className="hidden text-center tabular-nums md:table-cell">
@@ -175,10 +175,10 @@ export function GroupStatisticsTable({ data, isLoading, error, className }: Grou
     const labels = useMemo(() => getOrganizationLabels(organizationType), [organizationType]);
     return (
         <Card className={`flex flex-col ${className ?? ''}`}>
-            <CardHeader className="pb-2">
+            <CardHeader className="p-4 pb-2">
                 <CardTitle className="text-base">{labels.group}별 통계</CardTitle>
             </CardHeader>
-            <CardContent className="min-h-0 flex-1 overflow-auto">
+            <CardContent className="min-h-0 flex-1 overflow-auto p-4 pt-0">
                 <GroupStatisticsContent data={data} isLoading={isLoading} error={error} />
             </CardContent>
         </Card>

--- a/apps/web/src/pages/dashboard/TopRankingCard.tsx
+++ b/apps/web/src/pages/dashboard/TopRankingCard.tsx
@@ -19,7 +19,7 @@ interface TopRankingCardProps {
 function RankingContent({ items, isLoading, error }: Omit<TopRankingCardProps, 'title'>) {
     if (isLoading) {
         return (
-            <div className="flex h-[150px] items-center justify-center">
+            <div className="flex h-[110px] items-center justify-center">
                 <LoadingSpinner />
             </div>
         );
@@ -27,14 +27,14 @@ function RankingContent({ items, isLoading, error }: Omit<TopRankingCardProps, '
     if (error) return <p className="text-sm text-destructive">데이터 로드 실패</p>;
     if (items.length > 0) {
         return (
-            <div className="space-y-2">
+            <div className="space-y-1 text-sm">
                 {items.map((item, index) => (
                     <div key={item.id} className="flex items-center justify-between">
                         <span className="truncate">
                             <span className="mr-2 font-medium text-muted-foreground">{index + 1}.</span>
                             {item.name}
                             {item.subText && (
-                                <span className="ml-1 text-sm text-muted-foreground">({item.subText})</span>
+                                <span className="ml-1 text-xs text-muted-foreground">({item.subText})</span>
                             )}
                         </span>
                         <span className="ml-2 whitespace-nowrap font-medium">
@@ -51,11 +51,11 @@ function RankingContent({ items, isLoading, error }: Omit<TopRankingCardProps, '
 
 export function TopRankingCard({ title, items, isLoading, error }: TopRankingCardProps) {
     return (
-        <Card>
-            <CardHeader>
+        <Card className="min-h-0">
+            <CardHeader className="p-4 pb-2">
                 <CardTitle className="text-base">{title}</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="p-4 pt-0">
                 <RankingContent items={items} isLoading={isLoading} error={error} />
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- 셀렉트(연/월/주차) 초기값을 오늘 기준으로 설정 (예: 2026-05-17 → 5월 / 3주차)
- 통계 페이지와 동일한 날짜 캘린더 Popover 추가 (기본값: 오늘)
- 셀렉트박스 폭 w-20 → w-28 (텍스트 잘림 방지)
- 학년별 통계 카드 고정 높이 h-[420px] — viewport 작아져도 안 잘림
- 성별 차트 / TOP 5 카드 패딩·height·radius 컴팩트화

## Test plan
- [ ] 데스크탑(>=1280px)에서 캘린더 필터·날짜 캘린더 정상 표시, 오늘 기준 셋업 확인
- [ ] 작은 데스크탑(1024×600)에서 학년별 통계 카드 안 잘리고 모든 row 표시
- [ ] 모바일(<768px)은 셀렉트 그룹 숨김 유지 (/statistics로 유도)
- [ ] 날짜 캘린더 Popover 클릭 → 날짜 변경 → 통계 데이터 갱신 확인
- [ ] 연/월/주차 변경 시 selectedDay 자동 reset 확인
- [ ] 통계 페이지(/statistics) 데스크탑/모바일 둘 다 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)