### PR TITLE
feat: Lenit 피드백 위젯 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,7 @@ jobs:
         env:
           VITE_GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
           VITE_CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
+          VITE_LENIT_BOARD_KEY: ${{ secrets.LENIT_BOARD_KEY }}
         run: pnpm turbo build --filter=@school/web
 
       # SCP는 tar 압축해제 시 기존 디렉토리에 utime/chmod를 시도하므로,

--- a/apps/api/src/domains/account/application/get-account.usecase.ts
+++ b/apps/api/src/domains/account/application/get-account.usecase.ts
@@ -4,8 +4,11 @@
  * 인증된 사용자의 계정 정보 반환 (DB 조회)
  */
 import type { AccountInfo, GetAccountOutput, JoinRequestStatus, Role } from '@school/shared';
+import { getNowKST } from '@school/utils';
 import { TRPCError } from '@trpc/server';
 import { database } from '~/infrastructure/database/database.js';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 export class GetAccountUseCase {
     async execute(account: AccountInfo): Promise<GetAccountOutput> {
@@ -15,6 +18,7 @@ export class GetAccountUseCase {
                 id: true,
                 name: true,
                 displayName: true,
+                createdAt: true,
                 privacyAgreedAt: true,
                 privacyPolicyVersion: true,
                 organizationId: true,
@@ -29,12 +33,16 @@ export class GetAccountUseCase {
             });
         }
 
-        const { id, name, displayName, privacyAgreedAt, privacyPolicyVersion, organizationId, role } = found;
+        const { id, name, displayName, createdAt, privacyAgreedAt, privacyPolicyVersion, organizationId, role } = found;
+
+        // 가입 후 경과일: DB/서버 모두 KST 기준이므로 getNowKST() - createdAt 델타로 정합하게 계산
+        const signupDays = Math.max(0, Math.floor((getNowKST().getTime() - createdAt.getTime()) / MS_PER_DAY));
 
         const result: GetAccountOutput = {
             id: String(id),
             name,
             displayName,
+            signupDays,
             privacyAgreedAt,
             privacyPolicyVersion,
         };

--- a/apps/api/test/integration/account.test.ts
+++ b/apps/api/test/integration/account.test.ts
@@ -29,6 +29,15 @@ describe('account 통합 테스트', () => {
             expect(result.name).toBe(seed.account.name);
         });
 
+        it('응답에 signupDays(가입 경과일, 0 이상 정수) 포함', async () => {
+            const caller = createAuthenticatedCaller(seed.ids.accountId, seed.account.name);
+            const result = await caller.account.get();
+
+            expect(typeof result.signupDays).toBe('number');
+            expect(result.signupDays).toBeGreaterThanOrEqual(0);
+            expect(Number.isInteger(result.signupDays)).toBe(true);
+        });
+
         it('응답에 privacyPolicyVersion 포함 (현재 버전)', async () => {
             const caller = createAuthenticatedCaller(seed.ids.accountId, seed.account.name);
             const result = await caller.account.get();

--- a/apps/web/src/components/common/PrivacyPolicyDialog.tsx
+++ b/apps/web/src/components/common/PrivacyPolicyDialog.tsx
@@ -35,7 +35,14 @@ export const PrivacyPolicyContent = () => (
         </div>
         <div>
             <p className="font-medium text-foreground">5. 개인정보 위탁 및 제3자 제공</p>
-            <p>없음</p>
+            <p>안정적인 서비스 제공을 위해 아래 업체에 개인정보 처리를 위탁합니다.</p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-5">
+                <li>클라우드 인프라 운영: Amazon Web Services, Inc.</li>
+                <li>서비스 이용 통계 분석: Google LLC (Google Analytics)</li>
+                <li>서비스 이용 행태 분석: Microsoft Corporation (Microsoft Clarity)</li>
+                <li>사용자 피드백 수집 및 관리: Lenit (lenit.cloud)</li>
+            </ul>
+            <p className="mt-1">제3자 제공은 법령에 근거가 있는 경우에 한합니다.</p>
         </div>
         <div>
             <p className="font-medium text-foreground">6. 이용자 권리</p>

--- a/apps/web/src/features/auth/AuthProvider.tsx
+++ b/apps/web/src/features/auth/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import type { AccountInfo, JoinRequestStatus } from '@school/shared';
 import { type ReactNode, createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { analytics } from '~/lib/analytics';
+import { loadLenit } from '~/lib/lenit';
 import { queryClient } from '~/lib/queryClient';
 import { trpc } from '~/lib/trpc';
 
@@ -107,6 +108,15 @@ export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
 
                 // GA4 사용자 속성 설정
                 analytics.setUserProperties(accountData.displayName, accountData.organizationName ?? null);
+
+                // Lenit 피드백 위젯 로드 (인증 사용자에게만, 멱등)
+                // traits는 세그먼트 분석용 비식별 범주값만 — 식별 가능한 이름/조직명은 제외
+                loadLenit(accountData.id, {
+                    signupDays: accountData.signupDays,
+                    hasOrganization: !!accountData.organizationId,
+                    ...(accountData.role ? { role: accountData.role } : {}),
+                    ...(accountData.organizationType ? { organizationType: accountData.organizationType } : {}),
+                });
             } else {
                 clearAuthState();
                 setAccount(null);

--- a/apps/web/src/lib/lenit.ts
+++ b/apps/web/src/lib/lenit.ts
@@ -1,0 +1,61 @@
+/**
+ * Lenit 피드백 위젯 로더
+ *
+ * 인증 사용자에게 플로팅 피드백 버튼(https://lenit.cloud)을 노출한다.
+ * - VITE_LENIT_BOARD_KEY 미설정 시 no-op (로컬/테스트/개발 환경 격리)
+ * - userId가 비어있으면 no-op (로그인 직후 PK 미확정 과도기 보호)
+ * - 세션 내 스크립트는 1회만 주입 (StrictMode 이중 렌더/계정 재설정에도 멱등)
+ * - 로드 실패가 앱 동작을 막지 않음 (에러 격리)
+ *
+ * 트리거: 계정 로드 완료 시 (AuthProvider)
+ */
+
+const WIDGET_SRC = 'https://lenit.cloud/widget.js';
+
+/** Lenit 세그먼트용 앱 공통 상수 속성 (모든 사용자 동일). 식별 정보 없음. */
+const STATIC_TRAITS: LenitTraits = {
+    plan: 'free',
+    language: 'ko',
+    country: 'KR',
+    industry: 'religious-education',
+};
+
+let loaded = false;
+
+const getBoardKey = (): string | null => {
+    return import.meta.env.VITE_LENIT_BOARD_KEY?.trim() || null;
+};
+
+/**
+ * Lenit 위젯을 로드한다. 조건 미충족 시 조용히 no-op.
+ * @param userId 로그인 계정 PK (account.id, 문자열)
+ * @param traits 세그먼트 분석용 동적 속성 (선택). 앱 공통 상수(STATIC_TRAITS)와 병합되어 전송된다.
+ */
+export const loadLenit = (userId: string, traits?: LenitTraits): void => {
+    if (loaded || !userId) return;
+
+    const boardKey = getBoardKey();
+    if (!boardKey) return;
+
+    // HMR/모듈 재로드로 loaded 플래그가 초기화돼도 스크립트 중복 주입 방지
+    if (document.querySelector(`script[src="${WIDGET_SRC}"]`)) {
+        loaded = true;
+        return;
+    }
+
+    try {
+        const config: LenitConfig = { boardKey, userId, traits: { ...STATIC_TRAITS, ...traits } };
+
+        window.Lenit = window.Lenit || [];
+        window.Lenit.push(config);
+
+        const script = document.createElement('script');
+        script.src = WIDGET_SRC;
+        script.async = true;
+        document.body.appendChild(script);
+
+        loaded = true;
+    } catch (error) {
+        console.warn('[Lenit] 위젯 로드 실패:', error);
+    }
+};

--- a/apps/web/src/pages/legal/PrivacyPage.tsx
+++ b/apps/web/src/pages/legal/PrivacyPage.tsx
@@ -83,6 +83,7 @@ export function PrivacyPage() {
                     <li>클라우드 인프라 운영: Amazon Web Services, Inc.</li>
                     <li>서비스 이용 통계 분석: Google LLC (Google Analytics)</li>
                     <li>서비스 이용 행태 분석: Microsoft Corporation (Microsoft Clarity)</li>
+                    <li>사용자 피드백 수집 및 관리: Lenit (lenit.cloud)</li>
                 </ul>
             </section>
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -179,3 +179,15 @@
         transform: translateY(0);
     }
 }
+
+/*
+ * Lenit 피드백 위젯 런처 버튼(#vb-widget-root) 위치 보정.
+ * 위젯은 bottom:24px(inline, non-important)로 고정되는데, 모바일에서 BottomTabBar
+ * (md:hidden, 높이 --bottom-tab-bar-height)와 겹친다. md(768px) 미만에서만 탭바 위로 올린다.
+ * 패널(#vb-panel)은 열릴 때 bottom:0 풀시트라 영향 없음.
+ */
+@media (max-width: 767px) {
+    #vb-widget-root {
+        bottom: calc(var(--bottom-tab-bar-height) + env(safe-area-inset-bottom) + 1rem) !important;
+    }
+}

--- a/apps/web/src/types/lenit.d.ts
+++ b/apps/web/src/types/lenit.d.ts
@@ -1,0 +1,16 @@
+type LenitTraitValue = string | number | boolean;
+type LenitTraits = Record<string, LenitTraitValue>;
+
+interface LenitConfig {
+    boardKey: string;
+    userId: string;
+    traits?: LenitTraits;
+}
+
+interface Window {
+    Lenit?: LenitConfig[];
+}
+
+interface ImportMetaEnv {
+    readonly VITE_LENIT_BOARD_KEY?: string;
+}

--- a/apps/web/test/lenit.test.ts
+++ b/apps/web/test/lenit.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const WIDGET_SRC = 'https://lenit.cloud/widget.js';
+
+/** loadLenit이 모든 payload에 병합하는 앱 공통 상수 traits */
+const STATIC_TRAITS = { plan: 'free', language: 'ko', country: 'KR', industry: 'religious-education' };
+
+/**
+ * loadLenit은 모듈 레벨 `loaded` 플래그로 멱등성을 보장하므로,
+ * 각 테스트마다 vi.resetModules()로 모듈을 새로 import 해 상태를 초기화한다.
+ */
+const importFresh = async () => {
+    vi.resetModules();
+    return import('~/lib/lenit');
+};
+
+const scriptCount = (): number => document.querySelectorAll(`script[src="${WIDGET_SRC}"]`).length;
+
+describe('loadLenit', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        delete (window as { Lenit?: unknown }).Lenit;
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('TC-1: 유효한 boardKey + userId면 큐에 push하고 스크립트를 1회 주입한다 (상수 traits 병합)', async () => {
+        vi.stubEnv('VITE_LENIT_BOARD_KEY', 'vb_test_key');
+        const { loadLenit } = await importFresh();
+
+        loadLenit('user-123');
+
+        expect(window.Lenit).toEqual([{ boardKey: 'vb_test_key', userId: 'user-123', traits: STATIC_TRAITS }]);
+        expect(scriptCount()).toBe(1);
+    });
+
+    it('TC-1b: 동적 traits는 상수 traits 위에 병합된다', async () => {
+        vi.stubEnv('VITE_LENIT_BOARD_KEY', 'vb_test_key');
+        const { loadLenit } = await importFresh();
+
+        loadLenit('user-123', { role: 'TEACHER', hasOrganization: true, signupDays: 12 });
+
+        expect(window.Lenit).toEqual([
+            {
+                boardKey: 'vb_test_key',
+                userId: 'user-123',
+                traits: { ...STATIC_TRAITS, role: 'TEACHER', hasOrganization: true, signupDays: 12 },
+            },
+        ]);
+    });
+
+    it('TC-2: 두 번 호출해도 스크립트는 1회만 주입된다 (멱등)', async () => {
+        vi.stubEnv('VITE_LENIT_BOARD_KEY', 'vb_test_key');
+        const { loadLenit } = await importFresh();
+
+        loadLenit('user-123');
+        loadLenit('user-123');
+
+        expect(window.Lenit).toHaveLength(1);
+        expect(scriptCount()).toBe(1);
+    });
+
+    it('TC-E1: boardKey가 없으면 push/주입을 하지 않는다', async () => {
+        vi.stubEnv('VITE_LENIT_BOARD_KEY', '');
+        const { loadLenit } = await importFresh();
+
+        loadLenit('user-123');
+
+        expect(window.Lenit).toBeUndefined();
+        expect(scriptCount()).toBe(0);
+    });
+
+    it('TC-E2: userId가 빈 문자열이면 push/주입을 하지 않는다', async () => {
+        vi.stubEnv('VITE_LENIT_BOARD_KEY', 'vb_test_key');
+        const { loadLenit } = await importFresh();
+
+        loadLenit('');
+
+        expect(window.Lenit).toBeUndefined();
+        expect(scriptCount()).toBe(0);
+    });
+});

--- a/docs/specs/functional-design/lenit-widget.md
+++ b/docs/specs/functional-design/lenit-widget.md
@@ -36,6 +36,7 @@
     - `loadLenit`이 상수 위에 동적값을 병합해 전송.
 - **signupDays 산출(서버)**: DB/서버 모두 KST 기준이므로 클라에서 계산하면 직렬화/타임존 이중 오프셋이 발생한다. `account.get` usecase가 `getNowKST() - createdAt` 델타로 일 단위 계산(음수 0 클램프)해 `signupDays: number`로 반환. 클라는 받은 값을 그대로 trait에 전달.
 - **에러 격리**: 주입 로직을 try/catch로 감싸 실패 시 `console.warn`만 남기고 앱 흐름 비차단(`analytics.ts`의 `safeGtag` 패턴 준수).
+- **모바일 위치 보정**: 위젯 런처(`#vb-widget-root`)는 `bottom:24px` 고정이라 모바일 `BottomTabBar`(`md:hidden`, `--bottom-tab-bar-height`)와 겹친다. `globals.css`에서 `max-width:767px`일 때 `bottom`을 탭바 높이+safe-area 위로 올린다(`!important`로 위젯 inline 스타일 오버라이드). Lenit은 bottom 오프셋 설정이 없어 CSS로 처리.
 
 ### 전역 타입
 

--- a/docs/specs/functional-design/lenit-widget.md
+++ b/docs/specs/functional-design/lenit-widget.md
@@ -1,0 +1,79 @@
+# 기능 설계: Lenit 피드백 위젯 통합
+
+> 상태: Draft | 작성일: 2026-05-24
+
+> PRD: `docs/specs/prd/lenit-widget.md`
+
+## 흐름/상태
+
+### 로드 플로우
+
+1. 사용자가 로그인 → `AuthProvider`가 `account.get` 응답으로 계정 상태를 세팅(`AuthProvider.tsx`의 account 세팅 effect).
+2. GA4 사용자 속성 설정과 같은 지점에서 `loadLenit(account.id)` 호출.
+3. `loadLenit`은 다음을 검사:
+    - `VITE_LENIT_BOARD_KEY`가 유효한가(미설정/플레이스홀더 아님)?
+    - 이미 로드했는가(모듈 레벨 `loaded` 플래그)?
+    - 둘 중 하나라도 막히면 즉시 return(no-op).
+4. 통과 시 `window.Lenit = window.Lenit || []` 초기화 → `window.Lenit.push({ boardKey, userId, traits? })` → `widget.js` `<script async>`를 `document.body`에 1회 append.
+5. `widget.js`가 큐를 소비해 플로팅 버튼 + 패널을 자동 렌더.
+
+### 상태 전이
+
+```
+[미인증] --로그인/계정로드--> [인증] --loadLenit()--> [위젯 로드됨(세션 1회)]
+[위젯 로드됨] --로그아웃--> [account=null, 위젯은 새로고침 전까지 잔존] (teardown 미지원)
+```
+
+## 동작 명세
+
+- **주입 위치**: `apps/web/src/lib/lenit.ts` (분리 유틸, `analytics.ts`와 동형). 호출은 `AuthProvider`의 계정 세팅 effect.
+- **env 가드**: GA4/Clarity와 동일하게 값이 비었거나 `VITE_`/`%` 플레이스홀더면 스킵. → dev/test/로컬에서 자동 비활성.
+- **멱등성**: 모듈 레벨 `loaded` boolean. StrictMode 이중 렌더, 계정 재설정, 재마운트에도 스크립트 1회만 append.
+- **userId**: `account.id`(cuid 문자열). 빈 문자열(`''`)이면 로드 스킵 — 로그인 직후 `account.id`가 `''`인 과도기(`AuthProvider.tsx`의 login 직후 상태) 보호.
+- **traits(세그먼트 속성)**: 비식별 값만 전송. 식별 가능한 `displayName`/`organizationName`/`churchName`은 third-party 노출 최소화를 위해 **제외**.
+    - 앱 공통 상수(`lenit.ts`의 `STATIC_TRAITS`): `plan:'free'`(유료 티어 없음), `language:'ko'`, `country:'KR'`, `industry:'religious-education'`.
+    - 동적(계정별, `AuthProvider`): `signupDays`(가입 경과일), `hasOrganization`(boolean), `role`(ADMIN/TEACHER, 조직 소속 시), `organizationType`(ELEMENTARY/MIDDLE_HIGH/YOUNG_ADULT, 조직 소속 시).
+    - `loadLenit`이 상수 위에 동적값을 병합해 전송.
+- **signupDays 산출(서버)**: DB/서버 모두 KST 기준이므로 클라에서 계산하면 직렬화/타임존 이중 오프셋이 발생한다. `account.get` usecase가 `getNowKST() - createdAt` 델타로 일 단위 계산(음수 0 클램프)해 `signupDays: number`로 반환. 클라는 받은 값을 그대로 trait에 전달.
+- **에러 격리**: 주입 로직을 try/catch로 감싸 실패 시 `console.warn`만 남기고 앱 흐름 비차단(`analytics.ts`의 `safeGtag` 패턴 준수).
+
+### 전역 타입
+
+`apps/web/src/types/lenit.d.ts` (gtag.d.ts와 동형):
+
+| 심볼           | 형태                                   | 설명             |
+| -------------- | -------------------------------------- | ---------------- |
+| `LenitConfig`  | `{ boardKey: string; userId: string }` | push 페이로드    |
+| `Window.Lenit` | `LenitConfig[] \| undefined`           | 위젯 큐 (선택적) |
+
+### 환경변수
+
+| 변수                   | 위치             | 설명                                 |
+| ---------------------- | ---------------- | ------------------------------------ |
+| `VITE_LENIT_BOARD_KEY` | `apps/web/.env*` | Lenit 보드 키. 미설정 시 위젯 비활성 |
+
+## 예외/엣지 케이스
+
+| 상황                                       | 처리                                                           |
+| ------------------------------------------ | -------------------------------------------------------------- |
+| `VITE_LENIT_BOARD_KEY` 미설정/플레이스홀더 | no-op (위젯 미로드)                                            |
+| `account.id`가 빈 문자열                   | no-op (유효 PK 확보 후 재호출 시 로드)                         |
+| 이미 로드된 세션에서 재호출                | no-op (멱등)                                                   |
+| `widget.js` 네트워크 실패                  | 앱 비차단, Lenit 측 큐만 잔존                                  |
+| 로그아웃                                   | 위젯 잔존 허용(teardown 미지원), 새로고침 시 비인증이라 미로드 |
+
+## 측정/모니터링
+
+- 자체 GA4 이벤트는 추가하지 않음. 위젯 노출/피드백 지표는 Lenit 대시보드에서 확인.
+
+## 테스트 시나리오
+
+### 정상 케이스
+
+1. **TC-1**: 유효 boardKey + 유효 userId → `window.Lenit`에 `{boardKey, userId}` 1건 push, script 1개 append.
+2. **TC-2**: 동일 조건으로 `loadLenit` 2회 호출 → script append는 1회만(멱등).
+
+### 예외 케이스
+
+1. **TC-E1**: boardKey 미설정/플레이스홀더 → push/append 모두 없음.
+2. **TC-E2**: userId가 빈 문자열 → push/append 없음.

--- a/docs/specs/prd/lenit-widget.md
+++ b/docs/specs/prd/lenit-widget.md
@@ -1,0 +1,78 @@
+# PRD: Lenit 피드백 위젯 통합
+
+> 상태: Draft | 작성일: 2026-05-24
+
+> quick 플로우. 사용자 피드백 수집 도구(Lenit) 통합. 사업 문서 직접 연결 없음(운영 도구 도입).
+
+## 배경/문제 요약
+
+- 문제: 인증 사용자가 앱 내에서 의견/버그를 남길 채널이 없다. 현재는 인스타 DM 등 외부 경로에 의존.
+- 현재 상태: GA4/Clarity로 행동은 관측하지만, 사용자가 능동적으로 남기는 정성 피드백 수집 수단이 없음.
+- 목표 상태: 로그인 사용자에게 플로팅 피드백 버튼(Lenit 위젯)을 노출하여 앱을 떠나지 않고 피드백을 남기게 한다.
+
+## 목표/성공 기준
+
+- **목표**: 인증 사용자에게 Lenit 위젯을 안정적으로 로드하고, 사용자 식별자(`account.id`)와 함께 피드백을 수집.
+- **성공 지표**: 위젯 정상 로드(인증 사용자 세션에서 플로팅 버튼 노출), Lenit 보드에 `userId` 매핑된 피드백 유입.
+- **측정 기간**: 도입 후 4주.
+
+## 사용자/대상
+
+- **주요 사용자**: 로그인한 교리교사(인증 + 조직 소속 여부 무관, 계정 로드 완료 시점).
+- **사용 맥락**: 앱 사용 중 떠오른 의견/버그를 즉시 제출.
+
+## 범위
+
+### 포함
+
+- Lenit `widget.js` 스크립트 로드 + `window.Lenit.push({ boardKey, userId, traits })` 설정 주입
+- 세그먼트 분석용 `traits`는 비식별 값만: 상수(`plan:'free'`, `language:'ko'`, `country:'KR'`, `industry:'religious-education'`) + 계정별(`signupDays`, `hasOrganization`, `role`, `organizationType`). 식별 가능한 이름/조직명은 제외
+- `signupDays`는 서버(`account.get`)에서 KST 기준 계산해 반환(클라 타임존 이슈 회피). 출력에 `signupDays: number` 추가(백엔드)
+- `boardKey`는 환경변수(`VITE_LENIT_BOARD_KEY`)로 관리, 값이 없으면 로드 스킵(로컬/테스트/개발 격리)
+- `userId`는 로그인 계정 PK(`account.id`, 문자열) 사용
+- 계정 로드 완료 시점(AuthProvider)에 1회만 로드(멱등)
+
+### 제외
+
+- 비로그인 사용자 노출 (위젯은 인증 사용자에게만)
+- 위젯 UI 커스터마이징(색상/위치 등) — Lenit 기본값 사용
+- 로그아웃 시 위젯 제거(teardown) — Lenit 스니펫에 공개 API 없음, 새로고침 전까지 잔존 허용
+- 자체 피드백 백엔드/DB (Lenit이 SaaS로 전담)
+
+## 사용자 시나리오
+
+1. 교리교사가 로그인 → 계정 정보 로드 완료 → 화면 우하단에 Lenit 플로팅 버튼 노출.
+2. 버튼 클릭 → 패널에서 피드백 작성/제출 → Lenit 보드에 `userId=account.id`로 기록.
+
+## 요구사항
+
+### 필수 (Must)
+
+- [ ] `VITE_LENIT_BOARD_KEY`가 유효할 때만 위젯 로드 (미설정/플레이스홀더면 스킵)
+- [ ] 인증 사용자(계정 로드 완료)에게만 로드, `userId`에 `account.id` 문자열 전달
+- [ ] 동일 세션에서 스크립트는 1회만 주입 (StrictMode 중복 렌더/계정 재설정에도 멱등)
+- [ ] 로드 실패가 앱 동작에 영향을 주지 않음 (에러 격리, GA4/Clarity와 동일한 비차단 주입)
+
+### 선택 (Should)
+
+- [ ] `lib/lenit.ts` 유틸로 분리해 `analytics.ts`와 동일한 패턴/테스트 가능성 확보
+
+### 제외 (Out)
+
+- 위젯 표시 위치/테마 제어, 익명(비로그인) 모드
+
+## 제약/가정/리스크/의존성
+
+- **제약**: Lenit 위젯 스니펫은 `window.Lenit` 큐 → `widget.js` 비동기 로드 구조. teardown API 없음.
+- **가정**: `boardKey`(`vb_live_...`)는 공개 클라이언트 키로 시크릿 아님. `account.id`는 불투명 cuid PK.
+- **리스크(개인정보)**: third-party(lenit.cloud)로 `account.id` + 비식별 traits(`role`/`organizationType`/`hasOrganization`) 전송. 직접 PII(이름/이메일)는 아니며, 이미 GA4로 `displayName`/`organizationName`을 전송 중인 수준 이하. 인증 사용자에게만 로드되며 앱 페이지는 `ProtectedRoute`가 미동의 시 `/consent`로 리다이렉트하므로 사실상 동의 후 노출. **개인정보처리방침의 third-party 제공/위탁 고지에 Lenit 추가 검토 필요(후속).**
+- **외부 의존성**: `https://lenit.cloud/widget.js` 가용성.
+
+## 롤아웃/검증
+
+- **출시 단계**: 프로덕션 env에 `VITE_LENIT_BOARD_KEY` 설정 → 배포. dev/test는 미설정으로 자동 비활성.
+- **검증**: 인증 세션에서 플로팅 버튼 노출 확인, Lenit 대시보드에서 `userId` 매핑된 피드백 수신 확인.
+
+## 연결 문서
+
+- 기능 설계: `docs/specs/functional-design/lenit-widget.md`

--- a/packages/shared/src/schemas/account.ts
+++ b/packages/shared/src/schemas/account.ts
@@ -46,6 +46,8 @@ export interface GetAccountOutput {
     id: string;
     name: string;
     displayName: string;
+    /** 가입(계정 생성) 후 경과일. 서버에서 KST 기준 계산. */
+    signupDays: number;
     privacyAgreedAt: Date | null;
     privacyPolicyVersion: number;
     organizationId?: string;


### PR DESCRIPTION
## Summary
- 인증 사용자에게 Lenit 플로팅 피드백 위젯 로드 (`VITE_LENIT_BOARD_KEY` 설정 시에만, 로컬/테스트/dev 격리)
- userId=`account.id`, traits는 비식별 값만 — 상수(plan/language/country/industry) + 계정별(signupDays/hasOrganization/role/organizationType). 식별 정보(이름/조직명) 제외
- `signupDays`는 서버(`account.get`)에서 KST 기준 계산해 반환 (클라 타임존 이슈 회피)
- 개인정보처리방침 처리 위탁에 Lenit 명시
- `loaded` 플래그 + DOM 가드로 멱등, 로드 실패는 앱 비차단

## Test plan
- [x] 단위 테스트: lenit 위젯(멱등/env가드/payload), account.get signupDays
- [x] web 142 / api 326 / typecheck / build 5/5 통과
- [x] 로컬 수동 확인 (위젯 정상 동작)
- [x] 배포 전 GitHub Secrets `LENIT_BOARD_KEY` 등록 필요 (미등록 시 위젯 비활성)

## Pre-PR Review
- CRITICAL/HIGH: 없음 (typescript/database/silent-failure-hunter 발견 없음, 보안 MEDIUM은 방침 고지로 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)